### PR TITLE
Enable rigify properly

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
+++ b/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
@@ -795,16 +795,14 @@ def ensure_rigify():
             print("Rigify not found - enabling Rigify addon...")
             # addon_utils.disable("rigify")
             addon_utils.enable("rigify", default_set=True, persistent=True, handle_error=print)
-            print("Rigify enabled")
         except Exception as e:
             print(f"Error enabling Rigify addon - \n\n{e}")
             raise e
         
-    default, enabled = addon_utils.check("rigify")
-    print(f"Rigify default: {default}, enabled: {enabled}")
+    _, rigify_enabled = addon_utils.check("rigify")
 
-    if not enabled:
-        raise Exception("Rigify not enabled")
+    if not rigify_enabled:
+        raise Exception("Rigify not enabled, please enable it in your blender preferences and then close blender before retrying")
 
 def get_appended_number(rig_name):
     pattern = r"\.0[0-9]{2}$"

--- a/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
+++ b/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
@@ -793,7 +793,6 @@ def ensure_rigify():
     if not rigify_enabled:
         try:
             print("Rigify not found - enabling Rigify addon...")
-            # addon_utils.disable("rigify")
             addon_utils.enable("rigify", default_set=True, persistent=True, handle_error=print)
         except Exception as e:
             print(f"Error enabling Rigify addon - \n\n{e}")

--- a/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
+++ b/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
@@ -788,13 +788,12 @@ def add_rig(empty_names: List[str],
     return rig
 
 def ensure_rigify():
-    # TODO - This doesn't seem to work? Still need to install `rigify` manually :-/
-    rigify_enabled, _ = addon_utils.check("rigify")
+    _, rigify_enabled = addon_utils.check("rigify")
 
     if not rigify_enabled:
         try:
             print("Rigify not found - enabling Rigify addon...")
-            addon_utils.disable("rigify")
+            # addon_utils.disable("rigify")
             addon_utils.enable("rigify")
         except Exception as e:
             print(f"Error enabling Rigify addon - \n\n{e}")

--- a/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
+++ b/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
@@ -794,7 +794,8 @@ def ensure_rigify():
         try:
             print("Rigify not found - enabling Rigify addon...")
             # addon_utils.disable("rigify")
-            addon_utils.enable("rigify")
+            addon_utils.enable("rigify", persistent=True, handle_error=print)
+            print("Rigify enabled")
         except Exception as e:
             print(f"Error enabling Rigify addon - \n\n{e}")
             raise e

--- a/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
+++ b/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
@@ -798,6 +798,12 @@ def ensure_rigify():
         except Exception as e:
             print(f"Error enabling Rigify addon - \n\n{e}")
             raise e
+        
+    default, enabled = addon_utils.check("rigify")
+    print(f"Rigify default: {default}, enabled: {enabled}")
+
+    if not enabled:
+        raise Exception("Rigify not enabled")
 
 def get_appended_number(rig_name):
     pattern = r"\.0[0-9]{2}$"

--- a/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
+++ b/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
@@ -794,7 +794,7 @@ def ensure_rigify():
         try:
             print("Rigify not found - enabling Rigify addon...")
             # addon_utils.disable("rigify")
-            addon_utils.enable("rigify", persistent=True, handle_error=print)
+            addon_utils.enable("rigify", default_set=True, persistent=True, handle_error=print)
             print("Rigify enabled")
         except Exception as e:
             print(f"Error enabling Rigify addon - \n\n{e}")

--- a/ajc27_freemocap_blender_addon/main.py
+++ b/ajc27_freemocap_blender_addon/main.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-from ajc27_freemocap_blender_addon.core_functions.setup_scene import clear_scene
+from ajc27_freemocap_blender_addon.core_functions.setup_scene.clear_scene import clear_scene
 from ajc27_freemocap_blender_addon.data_models.parameter_models.load_parameters_config import \
     load_default_parameters_config
 from ajc27_freemocap_blender_addon.data_models.parameter_models.parameter_models import Config


### PR DESCRIPTION
This fixes the rigify enabling in `ensure_rigify` by referring to the correct return value from the `addon_utils.check()` return tuple. The tuple is given in `(default, state)` where default is whether the addon is set to open on default, and state is whether it is currently enabled. We were checking if it was set to be the default, not if it was currently enabled.

## Implementation Details
Due to some weirdness in the rigify setup, to enable rigify it has to be set to default, so we need to add the `default_set=True` flag for it to work. See [this stack exchange](https://blender.stackexchange.com/questions/242762/how-do-i-write-a-python-script-to-enable-the-rigify-add-on-given-this-failure-i). I've also set `persistent=True` to make sure rigify stays on (not entirely sure this is necessary), and `handle_errors=print`, which will cause any errors in the enabling process to be captured for debugging.

Finally, it does another check and throws an error if rigify isn't enabled at the end of the process, which helps it fail fast if something goes wrong in the enabling. I didn't follow the exception handling on this, but for some reason this helped it actually fail if rigify isn't enabled, whereas the except clause above wouldn't fully halt the process.

## Drawbacks
1) At least sometimes rigify throws an error when trying to enable it programmatically. I'm not sure why and couldn't isolate it, but it seems likely this will sometimes fail. In that case, it throws an error instructing the user to manually enable rigify.

2) This is based off the main branch, which has been updated quite a bit (with breaking changes) compared to the pip version freemocap uses. So we will need to figure out how to migrate this into a usable pip version best.

## To test
Uninstall the existing addon pip version, and pip install this branch with `pip install git+https://github.com/freemocap/freemocap_blender_addon@philip/enable_rigify_properly`. Then change every import of `run_as_main` to `main` in freemocap until there aren't errors. Finally, make sure rigify is not enabled in blender and blender is shut down, then export a session to blender and watch it work!

Tested and working with fresh installs of both Blender 3.6 and 4.1.
