### PR TITLE
Minor blender file clean up

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -326,6 +326,10 @@ class MainController:
         self._video_parent_object.hide_set(True)
         self._center_of_mass_parent_object.hide_set(True)
 
+        # remove default cube
+        if "Cube" in bpy.data.objects:
+            bpy.data.objects.remove(bpy.data.objects["Cube"])
+
         # create_scene_objects(scene=bpy.context.scene)
 
 

--- a/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
+++ b/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
@@ -29,9 +29,7 @@ def add_rig(empty_names: List[str],
             bpy.ops.object.armature_human_metarig_add()
         except Exception as e:
             raise e
-        
-        # Add normal human armature
-        bpy.ops.object.armature_human_metarig_add()
+
         # Rename metarig armature to rig_name
         bpy.data.armatures[0].name = rig_name
         # Get reference to armature

--- a/ajc27_freemocap_blender_addon/main.py
+++ b/ajc27_freemocap_blender_addon/main.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-from ajc27_freemocap_blender_addon.core_functions.setup_scene import clear_scene
+from ajc27_freemocap_blender_addon.core_functions.setup_scene.clear_scene import clear_scene
 from ajc27_freemocap_blender_addon.data_models.parameter_models.load_parameters_config import \
     load_default_parameters_config
 from ajc27_freemocap_blender_addon.data_models.parameter_models.parameter_models import Config


### PR DESCRIPTION
This PR makes two minor changes to clean up the Blender files output by the addon:

1) Removes the default cube from the Blender scene

2) Removes the additional unused metarig (or, more accurately, removes the addition of a second metarig that we never used)