### PR TITLE
Working patches

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
+++ b/ajc27_freemocap_blender_addon/core_functions/rig/add_rig.py
@@ -714,13 +714,16 @@ def add_rig(empty_names: List[str],
 
         # Create each constraint
         for bone_name, constraint_definitions in ALL_BONES_CONSTRAINT_DEFINITIONS.items():
+            if bone_name not in rig.pose.bones:
+                continue
+
             if not isinstance(constraint_definitions, list):
                 raise Exception(f'Constraint definitions for {bone_name} must be a list')
             
             # If it is a finger bone amd add_fingers_constraints is False continue with the next bone
             if not add_fingers_constraints and len(
                     [finger_part for finger_part in ['palm', 'thumb', 'index', 'middle', 'ring', 'pinky'] if
-                     finger_part in bone_constraint_definition]) > 0:
+                     finger_part in constraint_definitions]) > 0:
                 continue
 
             for constraint in constraint_definitions:

--- a/ajc27_freemocap_blender_addon/freemocap_data_handler/operations/enforce_rigid_bones/enforce_rigid_bones.py
+++ b/ajc27_freemocap_blender_addon/freemocap_data_handler/operations/enforce_rigid_bones/enforce_rigid_bones.py
@@ -107,7 +107,10 @@ def log_bone_statistics(bones: Dict[str, Dict[str, Any]], type: str):
         # Get the statistic values
         median_string = str(round(bone['median'] * 100, 7))
         stdev_string = str(round(bone['stdev'] * 100, 7))
-        cv_string = str(round(bone['stdev'] / bone['median'] * 100, 4))
+        try:
+            cv_string = str(round(bone['stdev'] / bone['median'] * 100, 4))
+        except ZeroDivisionError:
+            cv_string = 'N/A'
         log_string += f"{name:<15} {median_string:>12} {stdev_string:>12} {cv_string:>12}\n"
 
     print(log_string)


### PR DESCRIPTION
Some patches AJC and I found while working on porting his blender addon work here. These are minor functional changes that will benefit users while we make larger code changes.

## Changes:
- skips adding constraints if a bone name isn't found (can cause errors if there are missing tracked points in the freemocap data)
- searches the proper constraint definitions for fingers
- catches zero division errors in enforce rigid bones