### PR TITLE
Patch none error in COM mesh

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -243,7 +243,7 @@ class MainController:
                 parent_object=self._rigid_body_meshes_parent_object,
             )
         except Exception as e:
-            print(f"Failed to attach mesh to rig: {e}")
+            print(f"Failed to attach rigid bone meshes to rig: {e}")
             print(e)
             raise e
 
@@ -259,7 +259,7 @@ class MainController:
                 empties=self.empties
             )
         except Exception as e:
-            print(f"Failed to attach mesh to rig: {e}")
+            print(f"Failed to attach skelly mesh to rig: {e}")
             print(e)
             raise e
 
@@ -272,7 +272,7 @@ class MainController:
                 center_of_mass_empty=self.center_of_mass_empty,
             )
         except Exception as e:
-            print(f"Failed to attach mesh to rig: {e}")
+            print(f"Failed to attach center of mass mesh to rig: {e}")
             print(e)
             raise e
 
@@ -292,7 +292,7 @@ class MainController:
             )
 
         except Exception as e:
-            print(f"Failed to attach mesh to rig: {e}")
+            print(f"Failed to attach Center of Mass trail meshes to rig: {e}")
             print(e)
             raise e
 

--- a/ajc27_freemocap_blender_addon/core_functions/materials/create_checkerboard_material.py
+++ b/ajc27_freemocap_blender_addon/core_functions/materials/create_checkerboard_material.py
@@ -19,7 +19,8 @@ def create_checker_texture(material,
                            noise_scale: float,
                            square_scale: float) -> Tuple[bpy.types.NodeTree, bpy.types.Node]:
     nodes = material.node_tree.nodes
-    nodes.remove(nodes.get('Principled BSDF'))
+    if nodes.get('Principled BSDF'):
+        nodes.remove(nodes.get('Principled BSDF'))
     checker_node = nodes.new(type='ShaderNodeTexChecker')
 
     checker_node.inputs[1].default_value = color1


### PR DESCRIPTION
Checks if the `Principled BSDF` node is None before attempting to remove it.

Fixes https://github.com/freemocap/freemocap/issues/612

