### PR TITLE
Auto create new releases

### DIFF
--- a/.github/workflows/create_addon_install_zip.yaml
+++ b/.github/workflows/create_addon_install_zip.yaml
@@ -1,10 +1,9 @@
 name: Create and Upload Zip
 
 on:
-  push:
-    branches:
-      - main  # You can change this to any branch you want to trigger the action on
   workflow_dispatch:
+  push:
+    tags: [ v* ]
 
 jobs:
   build:
@@ -12,10 +11,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Create zip file
       run: zip -r freemocap_blender_addon.zip ajc27_freemocap_blender_addon/
+
+    - name: Get tag
+      id: get_tag
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "::set-output name=tag::$tag"
+
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #16.

Checklist from the issue:

## Create a GH Action that:
- [x]  On new `tag`
  - [x] Create `.zip` from `[repo-root]/freemocap_blender_addon/` folder 
  - [x] Create new `Release` (named `v[VersionTag] Release` or something)
  - [ ] Paste boiler plate instructions to Patch notes (see v1.3.0)
  - [ ] Auto generate Release notes
 
### Bonus!
- [ ] Create and run build tests, including: 
   - [ ] Install `.zip` to blender via subporocess `blender ...` call
   - [ ] Process `freemocap_test_data`  to produce a `freemocap_test_data_processed_with_[VersionTag].blend` file, and attach to the release

