### PR TITLE
Fixed BOS geometry node switch error due to blender version

### DIFF
--- a/freemocap_blender_addon/blender_ui/sub_panels/visualizer_panel.py
+++ b/freemocap_blender_addon/blender_ui/sub_panels/visualizer_panel.py
@@ -166,24 +166,24 @@ class VIEW3D_PT_data_view_panel(bpy.types.Panel):
             box.operator('freemocap._add_com_vertical_projection', text='Add COM Vertical Projection')
 
 
-        # # Base of Support
-        # row = layout.row(align=True)
-        # row.prop(ui_props, "show_base_of_support_options", text="",
-        #          icon='TRIA_DOWN' if ui_props.show_base_of_support_options else 'TRIA_RIGHT', emboss=False)
-        # row.label(text="Base of Support")
-        #
-        # if ui_props.show_base_of_support_options:
-        #     box = layout.box()
-        #     split = box.column().row().split(factor=0.5)
-        #     split.column().label(text="Z Threshold (m):")
-        #     split.column().prop(ui_props, ViewPanelPropNames.BASE_OF_SUPPORT_Z_THRESHOLD.value)
-        #     split = box.column().row().split(factor=0.5)
-        #     split.column().label(text="Point of Contact Radius (cm):")
-        #     split.column().prop(ui_props, ViewPanelPropNames.BASE_OF_SUPPORT_POINT_RADIUS.value)
-        #     split = box.column().row().split(factor=0.5)
-        #     split.column().label(text="Base of Support Color:")
-        #     split.column().prop(ui_props, ViewPanelPropNames.BASE_OF_SUPPORT_COLOR.value)
-        #     box.operator('freemocap._add_base_of_support', text='Add Base of Support')
+        # Base of Support
+        row = layout.row(align=True)
+        row.prop(ui_props, "show_base_of_support_options", text="",
+                 icon='TRIA_DOWN' if ui_props.show_base_of_support_options else 'TRIA_RIGHT', emboss=False)
+        row.label(text="Base of Support")
+        
+        if ui_props.show_base_of_support_options:
+            box = layout.box()
+            split = box.column().row().split(factor=0.5)
+            split.column().label(text="Z Threshold (m):")
+            split.column().prop(ui_props, ViewPanelPropNames.BASE_OF_SUPPORT_Z_THRESHOLD.value)
+            split = box.column().row().split(factor=0.5)
+            split.column().label(text="Point of Contact Radius (cm):")
+            split.column().prop(ui_props, ViewPanelPropNames.BASE_OF_SUPPORT_POINT_RADIUS.value)
+            split = box.column().row().split(factor=0.5)
+            split.column().label(text="Base of Support Color:")
+            split.column().prop(ui_props, ViewPanelPropNames.BASE_OF_SUPPORT_COLOR.value)
+            box.operator('freemocap._add_base_of_support', text='Add Base of Support')
         #
         # # Joint Angles
         # row = layout.row(align=True)

--- a/freemocap_blender_addon/core_functions/com_bos/add_bos.py
+++ b/freemocap_blender_addon/core_functions/com_bos/add_bos.py
@@ -13,7 +13,7 @@ def add_base_of_support(data_parent_empty: bpy.types.Object,
     # Add a plane mesh
     bpy.ops.mesh.primitive_plane_add(enter_editmode=False,
                                      align='WORLD',
-                                     location=(0, 0, 0.01),
+                                     location=(0, 0, 0.002),
                                      scale=(1, 1, 1))
 
     # Change the name of the plane mesh

--- a/freemocap_blender_addon/core_functions/com_bos/animate_bos_mesh.py
+++ b/freemocap_blender_addon/core_functions/com_bos/animate_bos_mesh.py
@@ -34,7 +34,11 @@ def animate_base_of_support(data_parent_empty:bpy.types.Object,
             break
     if com_projection_mesh is None:
         raise ValueError("COM Projection Mesh not found")
-    
+
+    # Set switch node index based on Blender version (to void an error)
+    switch_node_index = 1 if bpy.app.version < (4, 1, 0) else 0
+
+    # Get current frame to restore it at the end
     current_frame = scene.frame_current
 
     for frame in range(scene.frame_start, scene.frame_end):
@@ -61,24 +65,24 @@ def animate_base_of_support(data_parent_empty:bpy.types.Object,
                 bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Set Position_" + contact_point_object.name].inputs[3].keyframe_insert(data_path='default_value', frame=frame)
 
                 # Enable the Mesh Switch node
-                bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Switch_" + contact_point_object.name].inputs[1].enabled = True
+                bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Switch_" + contact_point_object.name].inputs[switch_node_index].default_value = True
 
                 # Insert a keyframe to the corresponding point
-                bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Switch_" + contact_point_object.name].inputs[1].keyframe_insert(data_path='enabled', frame=frame)
+                bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Switch_" + contact_point_object.name].inputs[switch_node_index].keyframe_insert(data_path='default_value', frame=frame)
 
             else:
 
                 # Disable the Circle Mesh node
-                bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Switch_" + contact_point_object.name].inputs[1].enabled = False
+                bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Switch_" + contact_point_object.name].inputs[switch_node_index].default_value = False
 
                 # Insert a keyframe to the corresponding point
-                bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Switch_" + contact_point_object.name].inputs[1].keyframe_insert(data_path='enabled', frame=frame)
+                bpy.data.node_groups["Geometry Nodes_base_of_support"].nodes["Switch_" + contact_point_object.name].inputs[switch_node_index].keyframe_insert(data_path='default_value', frame=frame)
 
         # Check if the COM Vertical Projection is intersecting with the base of support to change its material accordingly
         if base_of_support_visible:
 
             # Enable the BOS Visible Switch
-            bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["BOS Visible Switch"].inputs[1].enabled = True
+            bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["BOS Visible Switch"].inputs[switch_node_index].default_value = True
 
             # Get the location of the COM Vertical Projection
             com_vertical_projection_location = com_projection_mesh.matrix_world.translation
@@ -108,18 +112,18 @@ def animate_base_of_support(data_parent_empty:bpy.types.Object,
             # Check if the COM Vertical Projection is intersecting with the base of support
             if polygon.contains(point):
                 # Change the material of the COM Vertical Projection to In Base of Support
-                bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["In-Out BOS Switch"].inputs[1].default_value = True
+                bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["In-Out BOS Switch"].inputs[switch_node_index].default_value = True
             else:
                 # Change the material of the COM Vertical Projection to Out Base of Support
-                bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["In-Out BOS Switch"].inputs[1].default_value = False
+                bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["In-Out BOS Switch"].inputs[switch_node_index].default_value = False
 
         else:
             # Disable the BOS Visible Switch
-            bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["BOS Visible Switch"].inputs[1].enabled = False
+            bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["BOS Visible Switch"].inputs[switch_node_index].default_value = False
 
         # Insert a keyframe to the COM Vertical Projection switch nodes
-        bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["In-Out BOS Switch"].inputs[1].keyframe_insert(data_path='enabled', frame=frame)
-        bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["BOS Visible Switch"].inputs[1].keyframe_insert(data_path='enabled', frame=frame)
+        bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["In-Out BOS Switch"].inputs[switch_node_index].keyframe_insert(data_path='default_value', frame=frame)
+        bpy.data.node_groups["Geometry Nodes_COM_Vertical_Projection"].nodes["BOS Visible Switch"].inputs[switch_node_index].keyframe_insert(data_path='default_value', frame=frame)
 
     # Restore the current frame
     scene.frame_current = current_frame


### PR DESCRIPTION
@jonmatthis I added the variable named switch_node_index to consider the Blender version. I tested it with Blender 4.0 and 4.1 without problems. It should work for you. Let me know if it doesn't to take another look at it.

Maybe I'll check the joint angle function in another branch.

Another detail. When selecting a folder, it always adds the freemocap_sample_data string at the end of the path. So to load another folder I had to manually delete that part in the textbox.

