### PR TITLE
Fixed remaining ajc27 import and SKELLY_BONES obtention

### DIFF
--- a/freemocap_blender_addon/core_functions/meshes/skelly_mesh/attach_skelly_mesh.py
+++ b/freemocap_blender_addon/core_functions/meshes/skelly_mesh/attach_skelly_mesh.py
@@ -17,7 +17,7 @@ from freemocap_blender_addon.data_models.data_references import ArmatureType, Po
 from freemocap_blender_addon.data_models.armatures.bone_name_map import (
     bone_name_map,
 )
-from ajc27_freemocap_blender_addon.data_models.meshes.skelly_bones import (
+from freemocap_blender_addon.data_models.meshes.skelly_bones import (
     skelly_bone_names,
     get_skelly_bones,
 )
@@ -73,6 +73,9 @@ def attach_skelly_by_bone_mesh(
 
     # Change to edit mode
     bpy.ops.object.mode_set(mode='EDIT')
+
+    # Get the skelly bones dictionary
+    SKELLY_BONES = get_skelly_bones()
 
     #  Iterate through the skelly bones dictionary and update the
     #  default origin, length and normalized direction


### PR DESCRIPTION
@jonmatthis I tried to export from FreeMoCap with the main branch after all the merges and the addon was failing to load. There were a couple of errors in the attach_skelly_mesh. Now it exports correctly from the GUI.