### PR TITLE
update images as planes load for 4.2

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/load_videos/load_videos.py
+++ b/ajc27_freemocap_blender_addon/core_functions/load_videos/load_videos.py
@@ -1,27 +1,66 @@
-from pathlib import Path
-from typing import Union
-
 import addon_utils
 import bpy
 import numpy as np
+from pathlib import Path
+from typing import Union
 
 
-def get_video_paths(path_to_video_folder: Path) -> list:
+def get_video_paths(path_to_video_folder: str) -> list[str]:
     """Search the folder for 'mp4' files (case insensitive) and return them as a list"""
     print(f"Searching for videos in {path_to_video_folder}")
     list_of_video_paths = list(Path(path_to_video_folder).glob("*.mp4")) + list(
         Path(path_to_video_folder).glob("*.MP4")
     )
     unique_list_of_video_paths = list(set(list_of_video_paths))
+    paths_as_str = [str(path) for path in unique_list_of_video_paths]
+    return paths_as_str
 
-    return unique_list_of_video_paths
 
-
-def add_videos_to_scene(videos_path: Union[Path, str],
+def add_videos_to_scene(videos_directory: str,
                         parent_object: bpy.types.Object,
-                        video_location_scale: float = 4,
-                        video_size_scale: float = 5,
+                        video_scale: float = 3,
                         ):
+    print(f"Adding videos to scene...")
+    video_paths = get_video_paths(videos_directory)
+
+    bpy.ops.image.import_as_mesh_planes(use_backface_culling=False,
+                                        files=[{"name":path} for path in video_paths],
+                                        directory=videos_directory,
+                                        offset=True,
+                                        height=video_scale,
+                                        offset_amount= video_scale*.1,
+                                        align_axis='-Y')
+    # gather all the imported objects
+    imported_objects = bpy.context.selected_objects
+
+    #find x min/max for each video
+    x_min = min([obj.location.x for obj in imported_objects])
+    x_max = max([obj.location.x for obj in imported_objects])
+
+
+    #center the videos
+    for obj in imported_objects:
+        obj.location.x -= (x_max + x_min) / 2
+        obj.location.y += video_scale/2
+        obj.location.z = video_scale/2 + 0.5
+
+
+
+
+    #add to videos collection
+    videos_collection = bpy.data.collections.new(name="Videos")
+    bpy.context.scene.collection.children.link(videos_collection)
+    for obj in imported_objects:
+        videos_collection.objects.link(obj)
+        obj.parent = parent_object
+
+
+
+def add_videos_to_scene_pre_4_2(videos_path: Union[Path, str],
+                                parent_object: bpy.types.Object,
+                                video_location_scale: float = 4,
+                                video_size_scale: float = 5,
+                                ):
     print(f"Adding videos to scene...")
 
     number_of_videos = len(list(get_video_paths(videos_path)))
@@ -30,14 +69,14 @@ def add_videos_to_scene(videos_path: Union[Path, str],
             video_number,
             video_path,
     ) in enumerate(get_video_paths(videos_path)):
-        print(f"Adding video: {video_path.name} to scene")
+        print(f"Adding video: {Path(video_path).name} to scene")
 
         bpy.ops.import_image.to_plane(
-            files=[{"name": video_path.name}],
-            directory=str(video_path.parent),
+            files=[{"name": Path(video_path).name}],
+            directory=str(Path(video_path).parent),
             shader="EMISSION",
         )
-        print(f"Added video: {video_path.name} to scene")
+        print(f"Added video: {Path(video_path).name} to scene")
         video_as_plane = bpy.context.editable_objects[-1]
         print(f"video_as_plane: {video_as_plane}")
         video_as_plane.name = "video_" + str(video_number)
@@ -55,8 +94,8 @@ def add_videos_to_scene(videos_path: Union[Path, str],
         video_as_plane.parent = parent_object
 
 
-def load_videos(recording_path: str,
-                parent_object: bpy.types.Object = None,):
+def load_videos_as_planes(recording_path: str,
+                          parent_object: bpy.types.Object = None, ):
     """
     ############################
     Load videos into scene using `videos_as_planes` addon
@@ -79,7 +118,11 @@ def load_videos(recording_path: str,
             print("Error enabling `io_import_images_as_planes` addon: ")
             print(e)
         try:
-            add_videos_to_scene(videos_path=videos_path, parent_object=parent_object)
+            if bpy.app.version[0] >= 4 and bpy.app.version[1] >= 2:
+                add_videos_to_scene(videos_directory=str(videos_path), parent_object=parent_object)
+            else:
+                add_videos_to_scene_pre_4_2(videos_path=str(videos_path), parent_object=parent_object)
+
         except Exception as e:
             print("Error adding videos to scene: ")
             print(e)

--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List
 
 import numpy as np
-from ajc27_freemocap_blender_addon.core_functions.load_videos.load_videos import load_videos
+from ajc27_freemocap_blender_addon.core_functions.load_videos.load_videos import load_videos_as_planes
 from ajc27_freemocap_blender_addon.core_functions.meshes.rigid_body_meshes.attach_rigid_body_meshes_to_rig import create_rigid_body_meshes
 from ajc27_freemocap_blender_addon.freemocap_data_handler.utilities.get_or_create_freemocap_data_handler import (
     get_or_create_freemocap_data_handler,
@@ -42,6 +42,11 @@ class MainController:
         self._empty_parent_object = None
         self._rigid_body_meshes_parent_object = None
         self._video_parent_object = None
+        try:
+            import bpy
+            self._blender_version = bpy.app.version
+        except ImportError:
+            self._blender_version = None
 
         self.config = config
 
@@ -307,7 +312,7 @@ class MainController:
     def add_videos(self):
         try:
             print("Loading videos as planes...")
-            load_videos(
+            load_videos_as_planes(
                 recording_path=self.recording_path,
                 parent_object=self._video_parent_object,
             )
@@ -359,6 +364,8 @@ class MainController:
 
         bpy.ops.wm.save_as_mainfile(filepath=str(self.blend_file_path))
         print(f"Saved .blend file to: {self.blend_file_path}")
+
+
     def export_3d_model(self):
         print("Exporting 3D model...")
         try:

--- a/ajc27_freemocap_blender_addon/main.py
+++ b/ajc27_freemocap_blender_addon/main.py
@@ -24,7 +24,7 @@ def ajc27_run_as_main_function(recording_path: str,
 
 
 if __name__ == "__main__" or __name__ == "<run_path>":
-    print("Load DataNING FREEMOCAP BLENDER ADDON...")
+    print("LoadING FREEMOCAP BLENDER ADDON...")
     try:
         argv = sys.argv
         print(f"Received command line arguments: {argv}")

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,6 @@ version = 1
 requires-python = ">=3.10, <3.13"
 
 [[package]]
-name = "freemocap-blender-addon"
-version = "2024.9.1024"
+name = "ajc27-freemocap-blender-addon"
+version = "2024.12.1033"
 source = { editable = "." }


### PR DESCRIPTION


Blender merged the 'Images as planes' plug-in with their core functionality in v4.2 (congrats to that dev team!)

This PR updates the method we use to load the annotated videos as planes. It also checks the bpy version being used and triggers the legacy method for pre-4.2 blender, so we should remain backwards compatible
