### PR TITLE
Ajc/addon multiple capture support

### DIFF
--- a/ajc27_freemocap_blender_addon/blender_ui/operators/_add_com_vertical_projection.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/operators/_add_com_vertical_projection.py
@@ -10,7 +10,7 @@ class FREEMOCAP_OT_add_com_vertical_projection(bpy.types.Operator):
 
     def execute(self, context):
         print("Adding COM Vertical Projection.......")
-        data_parent_empty = context.scene.freemocap_properties.data_parent_empty
+        data_parent_empty = bpy.data.objects[context.scene.freemocap_properties.scope_data_parent]
         # Add COM Vertical Projection
         add_com_vertical_projection(data_parent_empty=data_parent_empty,
                                     neutral_color=context.scene.freemocap_ui_properties.com_vertical_projection_neutral_color,

--- a/ajc27_freemocap_blender_addon/blender_ui/operators/_load_data.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/operators/_load_data.py
@@ -22,7 +22,6 @@ class FREEMOCAP_OT_load_data(bpy.types.Operator):
             controller = MainController(recording_path=recording_path,
                                         blend_file_path=str(Path(recording_path) / (Path(recording_path).stem + ".blend")),
                                         config=config)
-            # context.scene.freemocap_properties.data_parent_empty = controller.data_parent_empty
             controller.load_data()
         except Exception as e:
             print(f"Failed to run main_controller.load_data() with config:{config}: `{e}`")

--- a/ajc27_freemocap_blender_addon/blender_ui/operators/_load_data.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/operators/_load_data.py
@@ -22,7 +22,7 @@ class FREEMOCAP_OT_load_data(bpy.types.Operator):
             controller = MainController(recording_path=recording_path,
                                         blend_file_path=str(Path(recording_path) / (Path(recording_path).stem + ".blend")),
                                         config=config)
-            context.scene.freemocap_properties.data_parent_empty = controller.data_parent_empty
+            # context.scene.freemocap_properties.data_parent_empty = controller.data_parent_empty
             controller.load_data()
         except Exception as e:
             print(f"Failed to run main_controller.load_data() with config:{config}: `{e}`")

--- a/ajc27_freemocap_blender_addon/blender_ui/properties/core_properties.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/properties/core_properties.py
@@ -10,15 +10,15 @@ class FREEMOCAP_CORE_PROPERTIES(bpy.types.PropertyGroup):
         name="FreeMoCap data parent empty",
         description="Empty that serves as parent for all the freemocap empties",
         type=bpy.types.Object,
-        poll=lambda self, object_in: object_in.type == 'EMPTY',
-    )
+        # poll=lambda self, object_in: object_in.type == 'EMPTY',
+    ) # type: ignore
 
     recording_path: bpy.props.StringProperty(
         name="FreeMoCap recording path",
         description="Path to a freemocap recording",
         default=get_test_recording_path(),
         subtype='FILE_PATH',
-    )
+    ) # type: ignore
 
     video_export_profile: bpy.props.EnumProperty(
         name='',
@@ -28,4 +28,4 @@ class FREEMOCAP_CORE_PROPERTIES(bpy.types.PropertyGroup):
                ('showcase', 'Showcase', ''),
                ('scientific', 'Scientific', ''),
                ],
-    )
+    ) # type: ignore

--- a/ajc27_freemocap_blender_addon/blender_ui/properties/core_properties.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/properties/core_properties.py
@@ -1,7 +1,56 @@
 import bpy
+import re
 
 from ajc27_freemocap_blender_addon.freemocap_data_handler.utilities.load_data import get_test_recording_path
+from ajc27_freemocap_blender_addon.blender_ui.sub_panels.visualizer_panel import ViewPanelPropNamesElements
 
+# Function to enable or disable the ui elements checkboxes depending on the elements visibility
+def update_scope_ui_variables(self, context):
+
+    scope_data_parent = bpy.data.objects[context.scene.freemocap_properties.scope_data_parent]
+    for base_element in ViewPanelPropNamesElements:
+        if base_element == ViewPanelPropNamesElements.SHOW_TRACKED_POINTS:
+            tracked_points_parent = next((child for child in scope_data_parent.children_recursive if 'empties_parent' in child.name), None)
+            base_element_visible = (
+                any(
+                    child.type == 'EMPTY' 
+                    and not child.hide_get() 
+                    for child in tracked_points_parent.children_recursive
+                )
+            )
+        elif base_element == ViewPanelPropNamesElements.SHOW_RIGID_BODIES:
+            rigid_body_meshes_parent = next((child for child in scope_data_parent.children_recursive if 'rigid_body_meshes_parent' in child.name), None)
+            base_element_visible = (
+                any(
+                    child.type == 'MESH' 
+                    and not child.hide_get() 
+                    for child in rigid_body_meshes_parent.children_recursive
+                )
+            )
+        elif base_element == ViewPanelPropNamesElements.SHOW_VIDEOS:
+            videos_parent = next((child for child in scope_data_parent.children_recursive if 'videos_parent' in child.name), None)
+            base_element_visible = (
+                any(
+                    child.type == 'MESH' 
+                    and not child.hide_get() 
+                    for child in videos_parent.children_recursive
+                )
+            )
+        else:
+            base_element_visible = (
+                any(
+                    re.search(base_element.object_name_pattern, child.name) 
+                    and child.type == base_element.object_type 
+                    and not child.hide_get() 
+                    for child in scope_data_parent.children_recursive
+                )
+            )
+
+        setattr(
+            context.scene.freemocap_ui_properties,
+            base_element.property_name,
+            base_element_visible
+        )
 
 class FREEMOCAP_CORE_PROPERTIES(bpy.types.PropertyGroup):
     print("Initializing FREEMOCAP_PROPERTIES class...")
@@ -16,6 +65,7 @@ class FREEMOCAP_CORE_PROPERTIES(bpy.types.PropertyGroup):
         name="Scope data parent",
         description="Dropdown to select the data parent empty that defines the scope of the addon functions",
         items=lambda self, context: FREEMOCAP_CORE_PROPERTIES.get_collection_items(self),
+        update=lambda self, context: update_scope_ui_variables(self, context),
     ) # type: ignore
 
     recording_path: bpy.props.StringProperty(

--- a/ajc27_freemocap_blender_addon/blender_ui/properties/core_properties.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/properties/core_properties.py
@@ -6,11 +6,16 @@ from ajc27_freemocap_blender_addon.freemocap_data_handler.utilities.load_data im
 class FREEMOCAP_CORE_PROPERTIES(bpy.types.PropertyGroup):
     print("Initializing FREEMOCAP_PROPERTIES class...")
 
-    data_parent_empty: bpy.props.PointerProperty(
-        name="FreeMoCap data parent empty",
-        description="Empty that serves as parent for all the freemocap empties",
-        type=bpy.types.Object,
-        # poll=lambda self, object_in: object_in.type == 'EMPTY',
+    data_parent_collection: bpy.props.CollectionProperty(
+        name="FreeMoCap data parent empties",
+        description="A collection of empties to be used as parents",
+        type=bpy.types.PropertyGroup
+    ) # type: ignore
+
+    scope_data_parent: bpy.props.EnumProperty(
+        name="Scope data parent",
+        description="Dropdown to select the data parent empty that defines the scope of the addon functions",
+        items=lambda self, context: FREEMOCAP_CORE_PROPERTIES.get_collection_items(self),
     ) # type: ignore
 
     recording_path: bpy.props.StringProperty(
@@ -29,3 +34,13 @@ class FREEMOCAP_CORE_PROPERTIES(bpy.types.PropertyGroup):
                ('scientific', 'Scientific', ''),
                ],
     ) # type: ignore
+
+    @staticmethod
+    def get_collection_items(self):
+        items = []
+        if self.data_parent_collection is None:
+            items = [('', '', '')]
+        else:
+            for idx, item in enumerate(self.data_parent_collection):
+                items.append((item.name, item.name, ""))
+        return items

--- a/ajc27_freemocap_blender_addon/blender_ui/properties/ui_properties.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/properties/ui_properties.py
@@ -2,6 +2,7 @@ import re
 
 import bpy
 from ajc27_freemocap_blender_addon.blender_ui.sub_panels.visualizer_panel import ViewPanelPropNames
+from ajc27_freemocap_blender_addon.blender_ui.sub_panels.visualizer_panel import ViewPanelPropNamesElements
 
 class FREEMOCAP_UI_PROPERTIES(bpy.types.PropertyGroup):
     show_base_elements_options: bpy.props.BoolProperty(
@@ -13,91 +14,109 @@ class FREEMOCAP_UI_PROPERTIES(bpy.types.PropertyGroup):
         name='Armature',
         description='Show Armature',
         default=True,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_ARMATURE.value,
-                                                      parent_pattern=r'_rig\Z|root\Z',
-                                                      toggle_children_not_parent=False),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_ARMATURE.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_ARMATURE.object_name_pattern,
+            toggle_children_not_parent=False
+        ),
     )  # type: ignore
 
     show_skelly_mesh: bpy.props.BoolProperty(
         name='Skelly Mesh',
         default=True,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_SKELLY_MESH.value,
-                                                      parent_pattern=r'skelly_mesh',
-                                                      toggle_children_not_parent=False),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_SKELLY_MESH.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_SKELLY_MESH.object_name_pattern,
+            toggle_children_not_parent=False
+        ),
     )  # type: ignore
 
     show_tracked_points: bpy.props.BoolProperty(
         name='Tracked Points',
         default=True,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_TRACKED_POINTS.value,
-                                                      parent_pattern=r'empties_parent',
-                                                      toggle_children_not_parent=True),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_TRACKED_POINTS.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_TRACKED_POINTS.object_name_pattern,
+            toggle_children_not_parent=True
+        ),
     )  # type: ignore
 
     show_rigid_bodies: bpy.props.BoolProperty(
         name='Rigid Bodies',
         default=True,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_RIGID_BODIES.value,
-                                                      parent_pattern=r'rigid_body_meshes_parent',
-                                                      toggle_children_not_parent=True),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_RIGID_BODIES.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_RIGID_BODIES.object_name_pattern,
+            toggle_children_not_parent=True
+        ),
     )  # type: ignore
 
     show_center_of_mass: bpy.props.BoolProperty(
         name='Center of Mass',
         default=True,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_CENTER_OF_MASS.value,
-                                                      parent_pattern=r'center_of_mass_data_parent',
-                                                      toggle_children_not_parent=True),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_CENTER_OF_MASS.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_CENTER_OF_MASS.object_name_pattern,
+            toggle_children_not_parent=True
+        ),
     )  # type: ignore
 
     show_videos: bpy.props.BoolProperty(
         name='Capture Videos',
         default=True,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_VIDEOS.value,
-                                                      parent_pattern=r'videos_parent',
-                                                      toggle_children_not_parent=True),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_VIDEOS.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_VIDEOS.object_name_pattern,
+            toggle_children_not_parent=True
+        ),
     )  # type: ignore
 
     show_com_vertical_projection: bpy.props.BoolProperty(
         name='COM Vertical Projection',
         default=False,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_COM_VERTICAL_PROJECTION.value,
-                                                      parent_pattern=r'COM_Vertical_Projection',
-                                                      toggle_children_not_parent=False),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_COM_VERTICAL_PROJECTION.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_COM_VERTICAL_PROJECTION.object_name_pattern,
+            toggle_children_not_parent=False
+        ),
     )  # type: ignore
 
     show_joint_angles: bpy.props.BoolProperty(
         name='Joint Angles',
         default=False,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_JOINT_ANGLES.value,
-                                                      parent_pattern=r'joint_angles_parent',
-                                                      toggle_children_not_parent=True),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_JOINT_ANGLES.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_JOINT_ANGLES.object_name_pattern,
+            toggle_children_not_parent=True
+        ),
     )  # type: ignore
 
     show_base_of_support: bpy.props.BoolProperty(
         name='Base of Support',
         default=False,
-        update=lambda a, b: toggle_element_visibility(a,
-                                                      b,
-                                                      panel_property=ViewPanelPropNames.SHOW_BASE_OF_SUPPORT.value,
-                                                      parent_pattern=r'base_of_support',
-                                                      toggle_children_not_parent=False),
+        update=lambda a, b: toggle_element_visibility(
+            a,
+            b,
+            panel_property=ViewPanelPropNamesElements.SHOW_BASE_OF_SUPPORT.property_name,
+            parent_pattern=ViewPanelPropNamesElements.SHOW_BASE_OF_SUPPORT.object_name_pattern,
+            toggle_children_not_parent=False
+        ),
     )  # type: ignore
 
     show_motion_paths_options: bpy.props.BoolProperty(

--- a/ajc27_freemocap_blender_addon/blender_ui/properties/ui_properties.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/properties/ui_properties.py
@@ -395,7 +395,8 @@ def toggle_element_visibility(self,
                               parent_pattern: str,
                               toggle_children_not_parent: bool,)->None:
 
-    for data_object in context.scene.freemocap_properties.data_parent_empty.children_recursive:
+    data_parent_object = bpy.data.objects[context.scene.freemocap_properties.scope_data_parent]
+    for data_object in data_parent_object.children_recursive:
         if re.search(parent_pattern, data_object.name):
             hide_objects(data_object,
                          not bool(self[panel_property]),
@@ -421,8 +422,9 @@ def toggle_motion_path(self,
     bpy.ops.object.select_all(action='DESELECT')
 
     # Get reference to the object
+    data_parent_object = bpy.data.objects[context.scene.freemocap_properties.scope_data_parent]
     data_object_name = None
-    for child in context.scene.freemocap_properties.data_parent_empty.children_recursive:
+    for child in data_parent_object.children_recursive:
         if re.search(data_object_basename, child.name):
             data_object_name = child.name
             break

--- a/ajc27_freemocap_blender_addon/blender_ui/sub_panels/load_data_panel.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/sub_panels/load_data_panel.py
@@ -23,4 +23,4 @@ class VIEW3D_PT_load_data(bpy.types.Panel):
 
         # Save data to disk panel
         box = layout.box()
-        box.prop(context.scene.freemocap_properties, "data_parent_empty", text="Data Parent Empty")
+        box.prop(context.scene.freemocap_properties, "scope_data_parent", text="Scope Data Parent")

--- a/ajc27_freemocap_blender_addon/blender_ui/sub_panels/visualizer_panel.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/sub_panels/visualizer_panel.py
@@ -60,7 +60,7 @@ class VIEW3D_PT_data_view_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        if context.scene.freemocap_properties.data_parent_empty is None:
+        if context.scene.freemocap_properties.data_parent_collection is None:
             layout.label(text="Load a recording session to view data settings.")
             return
         ui_props = context.scene.freemocap_ui_properties

--- a/ajc27_freemocap_blender_addon/blender_ui/sub_panels/visualizer_panel.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/sub_panels/visualizer_panel.py
@@ -1,18 +1,26 @@
 import enum
+import re
 
 import bpy
 
-class ViewPanelPropNames(enum.Enum):
-    SHOW_ARMATURE = "show_armature"
-    SHOW_SKELLY_MESH = "show_skelly_mesh"
-    SHOW_TRACKED_POINTS = "show_tracked_points"
-    SHOW_RIGID_BODIES = "show_rigid_bodies"
-    SHOW_CENTER_OF_MASS = "show_center_of_mass"
-    SHOW_VIDEOS = "show_videos"
-    SHOW_COM_VERTICAL_PROJECTION = "show_com_vertical_projection"
-    SHOW_JOINT_ANGLES = "show_joint_angles"
-    SHOW_BASE_OF_SUPPORT = "show_base_of_support"
+class ViewPanelPropNamesElements(enum.Enum):
+    def __init__(self, property_name, object_name_pattern, object_type):
+        self.property_name = property_name
+        self.object_name_pattern = object_name_pattern
+        self.object_type = object_type
 
+    SHOW_ARMATURE = ("show_armature", "_rig(\.\d+)?$", "ARMATURE")
+    SHOW_SKELLY_MESH = ("show_skelly_mesh", "skelly_mesh", "MESH")
+    SHOW_TRACKED_POINTS = ("show_tracked_points", "empties_parent", "EMPTY")
+    SHOW_RIGID_BODIES = ("show_rigid_bodies", "rigid_body_meshes_parent", "EMPTY")
+    SHOW_CENTER_OF_MASS = ("show_center_of_mass", "center_of_mass", "MESH")
+    SHOW_VIDEOS = ("show_videos", "videos_parent", "EMPTY")
+    SHOW_COM_VERTICAL_PROJECTION = ("show_com_vertical_projection", "com_vertical_projection", "MESH")
+    SHOW_JOINT_ANGLES = ("show_joint_angles", "joint_angles_parent", "EMPTY")
+    SHOW_BASE_OF_SUPPORT = ("show_base_of_support", "base_of_support", "MESH")
+
+class ViewPanelPropNames(enum.Enum):
+    
     MOTION_PATH_SHOW_LINE = "motion_path_show_line"
     MOTION_PATH_LINE_THICKNESS = "motion_path_line_thickness"
     MOTION_PATH_USE_CUSTOM_COLOR = "motion_path_use_custom_color"
@@ -73,20 +81,18 @@ class VIEW3D_PT_data_view_panel(bpy.types.Panel):
 
         if ui_props.show_base_elements_options:
             box = layout.box()
-            split = box.column().row().split(factor=0.5)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_ARMATURE.value)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_SKELLY_MESH.value)
-            split = box.column().row().split(factor=0.5)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_TRACKED_POINTS.value)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_RIGID_BODIES.value)
-            split = box.column().row().split(factor=0.5)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_CENTER_OF_MASS.value)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_VIDEOS.value)
-            split = box.column().row().split(factor=0.5)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_COM_VERTICAL_PROJECTION.value)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_JOINT_ANGLES.value)
-            split = box.column().row().split(factor=0.5)
-            split.column().prop(ui_props, ViewPanelPropNames.SHOW_BASE_OF_SUPPORT.value)
+
+            scope_data_parent = bpy.data.objects[context.scene.freemocap_properties.scope_data_parent]
+            index = 0
+            for base_element in ViewPanelPropNamesElements:
+                if index % 2 == 0:  # even index
+                    split = box.column().row().split(factor=0.5)
+                object_name_pattern = base_element.object_name_pattern
+                object_type = base_element.object_type
+                element_exists = any(re.search(object_name_pattern, child.name) and child.type == object_type for child in scope_data_parent.children_recursive)
+                if element_exists:
+                    split.column().prop(ui_props, base_element.property_name)
+                index += 1
 
         # Motion Paths
         row = layout.row(align=True)

--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -403,9 +403,15 @@ class MainController:
         # self.create_video()
         self.export_3d_model()
 
-        # Set the data parent empty
-        bpy.context.scene.freemocap_properties.data_parent_empty = self.data_parent_empty
-        print("Data Parent Empty:", self.data_parent_empty.name)
+        # Add the data parent empty to the collection of data parents
+        new_data_parent = bpy.context.scene.freemocap_properties.data_parent_collection.add()
+        new_data_parent.name = self.data_parent_empty.name
+        try:
+            # Set the new data parent as the scope data parent in the addon ui
+            bpy.context.scene.freemocap_properties.scope_data_parent = self.data_parent_empty.name
+        except Exception as e:
+            # Addon ui not loaded
+            print(e)
 
         self.save_blender_file()
 

--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -390,6 +390,7 @@ class MainController:
         self.save_data_to_disk()
 
         #Blender stuff
+        import bpy
         self.create_empties()
         self.add_rig()
         self.save_bone_and_joint_data_from_rig()
@@ -401,4 +402,11 @@ class MainController:
         self.setup_scene()
         # self.create_video()
         self.export_3d_model()
+
+        # Set the data parent empty
+        bpy.context.scene.freemocap_properties.data_parent_empty = self.data_parent_empty
+        print("Data Parent Empty:", self.data_parent_empty.name)
+
         self.save_blender_file()
+
+        

--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -333,9 +333,9 @@ class MainController:
                         if space.type == "VIEW_3D":  # check if space is a 3D view
                             space.shading.type = "MATERIAL"
 
-        # self.data_parent_empty.hide_set(True)
         self._empty_parent_object.hide_set(True)
         self._rigid_body_meshes_parent_object.hide_set(True)
+        self.center_of_mass_empty.hide_set(True)
         self._video_parent_object.hide_set(True)
         self._data_parent_empty.hide_set(True)
 
@@ -403,10 +403,10 @@ class MainController:
         # self.create_video()
         self.export_3d_model()
 
-        # Add the data parent empty to the collection of data parents
-        new_data_parent = bpy.context.scene.freemocap_properties.data_parent_collection.add()
-        new_data_parent.name = self.data_parent_empty.name
         try:
+            # Add the data parent empty to the collection of data parents
+            new_data_parent = bpy.context.scene.freemocap_properties.data_parent_collection.add()
+            new_data_parent.name = self.data_parent_empty.name
             # Set the new data parent as the scope data parent in the addon ui
             bpy.context.scene.freemocap_properties.scope_data_parent = self.data_parent_empty.name
         except Exception as e:

--- a/ajc27_freemocap_blender_addon/core_functions/setup_scene/clear_scene.py
+++ b/ajc27_freemocap_blender_addon/core_functions/setup_scene/clear_scene.py
@@ -14,5 +14,10 @@ def clear_scene():
         bpy.ops.object.select_all(action="SELECT")  # select all objects
         bpy.ops.object.delete(use_global=True)  # delete all objects from all scenes
         bpy.ops.outliner.orphans_purge(do_local_ids=True, do_linked_ids=True, do_recursive=True)
+        # Clear data parent collection
+        bpy.context.scene.freemocap_properties.data_parent_collection.clear()
+        # Clear scene collections
+        for collection in bpy.data.collections:
+            bpy.data.collections.remove(collection)
     except:
         pass


### PR DESCRIPTION
@jonmatthis I started working on the addon again. I fixed the multiple capture support. I created a collection variable that manages the data parent empties added to the Blender scene. There is a selector that has only those parent empties so the rest of the functions are executed to only the selected parent children.

It works decently, even if you load the same capture multiple times. It works directly after the FreeMoCap export opens as long as the addon was previously enabled.

Here is an example:

https://github.com/user-attachments/assets/835d33e3-6261-4fcf-afc9-068524e866d2

I will continue to work on it but on different branches derived from this one.