### PR TITLE
Fix errors caused by Blender localization translations

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/create_rig/add_rig_bone_method.py
+++ b/ajc27_freemocap_blender_addon/core_functions/create_rig/add_rig_bone_method.py
@@ -63,7 +63,9 @@ def add_rig_by_bone(
     bpy.ops.object.mode_set(mode="EDIT")
 
     # Remove the default bone
-    rig.data.edit_bones.remove(rig.data.edit_bones["Bone"])
+    default_bone_name = bpy.app.translations.pgettext_data("Bone")
+    if default_bone_name in rig.data.edit_bones:
+        rig.data.edit_bones.remove(rig.data.edit_bones[default_bone_name])
 
     # Get the inverse bone_map_dict
     inv_bone_name_map = {

--- a/ajc27_freemocap_blender_addon/core_functions/create_video/helpers/reset_scene_defaults.py
+++ b/ajc27_freemocap_blender_addon/core_functions/create_video/helpers/reset_scene_defaults.py
@@ -7,7 +7,8 @@ def reset_scene_defaults() -> None:
         obj.hide_render = False
 
     # Hide the background if present
-    if "background" in bpy.data.objects:
-        bpy.data.objects["background"].hide_set(True)
+    background_name = bpy.app.translations.pgettext_data("background")
+    if background_name in bpy.data.objects:
+        bpy.data.objects[background_name].hide_set(True)
 
     return

--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -340,8 +340,9 @@ class MainController:
         self._data_parent_empty.hide_set(True)
 
         # remove default cube
-        if "Cube" in bpy.data.objects:
-            bpy.data.objects.remove(bpy.data.objects["Cube"])
+        cube_name = bpy.app.translations.pgettext_data("Cube")
+        if cube_name in bpy.data.objects:
+            bpy.data.objects.remove(bpy.data.objects[cube_name])
 
         # create_scene_objects(scene=bpy.context.scene)
 


### PR DESCRIPTION
These changes improve the addon's compatibility with non-English Blender environments. 

Hardcoded object names ("Bone", "background", "Cube") are replaced with localized names fetched via bpy.app.translations.pgettext_data(), preventing `KeyError` due to language settings.

Note: I only modified issues related to https://github.com/freemocap/freemocap/issues/720 as I'm not very familiar with Blender.