### PR TITLE
Ajc/calculate join angles function

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/calculate_joint_angles/calculate_joint_angles.py
+++ b/ajc27_freemocap_blender_addon/core_functions/calculate_joint_angles/calculate_joint_angles.py
@@ -1,0 +1,261 @@
+import numpy as np
+import math as m
+from mathutils import Vector
+
+from ajc27_freemocap_blender_addon.core_functions.calculate_joint_angles.joint_angle_definitions import joint_angles
+
+def calculate_joint_angles(
+    output_path: str,
+    marker_names: list,
+    marker_frame_xyz: np.ndarray
+):
+    print("Calculating joint angles...")
+
+    angle_list = list(joint_angles.keys())
+    # Initialize an array to hold the angle values with nans
+    angle_values = np.full((marker_frame_xyz.shape[0], len(angle_list)), np.nan)
+
+    for joint_angle in joint_angles:
+        for frame in range(marker_frame_xyz.shape[0]):
+
+            # Rotation plane normal to define rotation angle sign
+            rotation_plane_normal = None
+
+            # Get the reference vector definition
+            reference_vector_def = joint_angles[joint_angle]['reference_vector']
+
+            # Get the reference vector
+            if joint_angles[joint_angle]['reference_vector']['type'] == 'vector':
+                reference_vector_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_vector_origin'])]
+                reference_vector_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_vector_end'])]
+            
+                # Calculate the reference vector
+                reference_vector = Vector(reference_vector_end_position) - Vector(reference_vector_origin_position)
+
+            elif joint_angles[joint_angle]['reference_vector']['type'] == 'crossproduct':
+
+                cross_vector_1_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_1_origin'])]
+                cross_vector_1_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_1_end'])]
+                cross_vector_2_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_2_origin'])]
+                cross_vector_2_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_2_end'])]
+
+                # Calculate the cross product
+                cross_vector_1 = Vector(cross_vector_1_end_position) - Vector(cross_vector_1_origin_position)
+                cross_vector_2 = Vector(cross_vector_2_end_position) - Vector(cross_vector_2_origin_position)
+                #  Calculate the reference vector
+                reference_vector = cross_vector_1.cross(cross_vector_2)
+
+            elif joint_angles[joint_angle]['reference_vector']['type'] == 'doublecrossproduct':
+
+                cross_vector_1_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_1_origin'])]
+                cross_vector_1_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_1_end'])]
+                cross_vector_2_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_2_origin'])]
+                cross_vector_2_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_2_end'])]
+                cross_vector_3_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_3_origin'])]
+                cross_vector_3_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_3_end'])]
+
+                # Calculate the cross product
+                cross_vector_1 = Vector(cross_vector_1_end_position) - Vector(cross_vector_1_origin_position)
+                cross_vector_2 = Vector(cross_vector_2_end_position) - Vector(cross_vector_2_origin_position)
+                cross_vector_3 = Vector(cross_vector_3_end_position) - Vector(cross_vector_3_origin_position)
+                # Calculate the reference vector
+                reference_vector = cross_vector_1.cross(cross_vector_2).cross(cross_vector_3)
+
+            elif joint_angles[joint_angle]['reference_vector']['type'] == 'average':
+
+                average_vector_1_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_average_1_origin'])]
+                average_vector_1_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_average_1_end'])]
+                average_vector_2_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_average_2_origin'])]
+                average_vector_2_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_average_2_end'])]
+
+                # Calculate the average vector
+                average_vector_1 = Vector(average_vector_1_end_position) - Vector(average_vector_1_origin_position)
+                average_vector_2 = Vector(average_vector_2_end_position) - Vector(average_vector_2_origin_position)
+                #  Calculate the reference vector
+                reference_vector = (average_vector_1 + average_vector_2) / 2
+
+            else:
+                raise ValueError(f"Invalid reference vector type: {joint_angles[joint_angle]['reference_vector']['type']}")
+           
+
+            # Get the rotation vector definition
+            rotation_vector_def = joint_angles[joint_angle]['rotation_vector']
+
+            # Get the rotation marker positions
+            rotation_vector_origin_position = marker_frame_xyz[
+                frame, marker_names.index(rotation_vector_def['rotation_vector_origin'])
+            ]
+
+            # If the rotation_vector_end is just a marker name string
+            # then get the vector directly. If not, get the vector as
+            # the projection on the projection plane
+            if isinstance(rotation_vector_def['rotation_vector_end'], str):
+                rotation_vector_end_position = marker_frame_xyz[
+                    frame, marker_names.index(rotation_vector_def['rotation_vector_end'])
+                ]
+
+            else:
+                # Extract definitions
+                end_def = joint_angles[joint_angle]['rotation_vector']['rotation_vector_end']
+
+                # Get projected vector
+                proj_vec_origin = marker_frame_xyz[frame, marker_names.index(end_def['projected_vector_origin'])]
+                proj_vec_end = marker_frame_xyz[frame, marker_names.index(end_def['projected_vector_end'])]
+                
+                vec_to_project = proj_vec_end - proj_vec_origin
+
+                # --- Compute plane axes ---
+
+                # Axis 1
+                axis1_def = end_def['projection_plane']['plane_axis_1']
+
+                if axis1_def['type'] == 'vector':
+                    axis1_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_origin'])]
+                    axis1_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_end'])]
+
+                    axis1 = (Vector(axis1_end) - Vector(axis1_origin)).normalized()
+
+                elif axis1_def['type'] == 'crossproduct':
+                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_1_origin'])]
+                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_1_end'])]
+                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_2_origin'])]
+                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_2_end'])]
+
+                    vec1 = Vector(cp1_end) - Vector(cp1_origin)
+                    vec2 = Vector(cp2_end) - Vector(cp2_origin)
+
+                    axis1 = vec1.cross(vec2).normalized()
+
+                elif axis1_def['type'] == 'doublecrossproduct':
+                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_1_origin'])]
+                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_1_end'])]
+                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_2_origin'])]
+                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_2_end'])]
+                    cp3_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_3_origin'])]
+                    cp3_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_3_end'])]
+
+                    vec1 = Vector(cp1_end) - Vector(cp1_origin)
+                    vec2 = Vector(cp2_end) - Vector(cp2_origin)
+                    vec3 = Vector(cp3_end) - Vector(cp3_origin)
+
+                    axis1 = vec1.cross(vec2).cross(vec3).normalized()
+
+                elif axis1_def['type'] == 'average':
+                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_average_1_origin'])]
+                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_average_1_end'])]
+                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_average_2_origin'])]
+                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_average_2_end'])]
+
+                    vec1 = Vector(cp1_end) - Vector(cp1_origin)
+                    vec2 = Vector(cp2_end) - Vector(cp2_origin)
+
+                    axis1 = (vec1 + vec2) / 2
+
+                else:
+                    raise ValueError("Unsupported axis1 type")
+
+                # Axis 2
+                axis2_def = end_def['projection_plane']['plane_axis_2']
+                if axis2_def['type'] == 'vector':
+                    axis2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_origin'])]
+                    axis2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_end'])]
+
+                    axis2 = (Vector(axis2_end) - Vector(axis2_origin)).normalized()
+
+                elif axis2_def['type'] == 'crossproduct':
+                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_origin'])]
+                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_end'])]
+                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_2_origin'])]
+                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_2_end'])]
+
+                    vec1 = (Vector(cp1_end) - Vector(cp1_origin)).normalized()
+                    vec2 = (Vector(cp2_end) - Vector(cp2_origin)).normalized()
+
+                    axis2 = vec1.cross(vec2).normalized()
+
+                elif axis2_def['type'] == 'doublecrossproduct':
+                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_origin'])]
+                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_end'])]
+                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_2_origin'])]
+                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_2_end'])]
+                    cp3_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_3_origin'])]
+                    cp3_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_3_end'])]
+
+                    vec1 = (Vector(cp1_end) - Vector(cp1_origin)).normalized()
+                    vec2 = (Vector(cp2_end) - Vector(cp2_origin)).normalized()
+                    vec3 = (Vector(cp3_end) - Vector(cp3_origin)).normalized()
+
+                    axis2 = vec1.cross(vec2).cross(vec3).normalized()
+
+                elif axis2_def['type'] == 'average':
+                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_1_origin'])]
+                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_1_end'])]
+                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_2_origin'])]
+                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_2_end'])]
+
+                    vec1 = (Vector(cp1_end) - Vector(cp1_origin)).normalized()
+                    vec2 = (Vector(cp2_end) - Vector(cp2_origin)).normalized()
+
+                    axis2 = (vec1 + vec2) / 2
+
+                elif axis2_def['type'] == 'average_crossproduct':
+                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_1_origin'])]
+                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_1_end'])]
+                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_2_origin'])]
+                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_2_end'])]
+                    cp3_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_origin'])]
+                    cp3_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_end'])]
+
+                    vec1 = (Vector(cp1_end) - Vector(cp1_origin)).normalized()
+                    vec2 = (Vector(cp2_end) - Vector(cp2_origin)).normalized()
+                    avg = (vec1 + vec2) / 2
+
+                    vec3 = (Vector(cp3_end) - Vector(cp3_origin)).normalized()
+
+                    axis2 = avg.cross(vec3).normalized()                    
+
+                else:
+                    raise ValueError("Unsupported axis2 type")
+
+                # --- Project vector onto plane ---
+
+                # Define plane
+                plane_normal = axis1.cross(axis2).normalized()
+                vec_proj = vec_to_project - plane_normal * vec_to_project.dot(plane_normal)
+
+                # Final projected position
+                rotation_vector_end_position = proj_vec_origin + vec_proj
+
+                # Assign the plane normal as rotation_plane_normal
+                rotation_plane_normal = plane_normal
+
+
+            # Calculate the rotation vector
+            rotation_vector = Vector(rotation_vector_end_position) - Vector(rotation_vector_origin_position)
+
+            # Get the cross product of the reference vector and the rotation vector
+            cross_product = reference_vector.cross(rotation_vector)
+
+            # In case rotation_plane_normal is None then set it as the cross product
+            if rotation_plane_normal is None:
+                rotation_plane_normal = cross_product
+
+            rotation_angle = m.degrees(rotation_vector.angle(reference_vector))
+
+            if cross_product.dot(rotation_plane_normal) < 0:
+                rotation_angle = -rotation_angle
+
+            # Store the angle value in the angle_values array
+            angle_values[frame, angle_list.index(joint_angle)] = rotation_angle
+
+    # Write the angle values to a csv file. Use the angle_list as the header
+    np.savetxt(
+        output_path,
+        angle_values,
+        delimiter=",",
+        header=",".join(angle_list),
+        comments='',
+        fmt='%.8f',
+    )
+
+    return

--- a/ajc27_freemocap_blender_addon/core_functions/calculate_joint_angles/calculate_joint_angles.py
+++ b/ajc27_freemocap_blender_addon/core_functions/calculate_joint_angles/calculate_joint_angles.py
@@ -1,254 +1,243 @@
 import numpy as np
 import math as m
 from mathutils import Vector
+from typing import Dict, List, Tuple, Optional
 
-from ajc27_freemocap_blender_addon.core_functions.calculate_joint_angles.joint_angle_definitions import joint_angles
+from ajc27_freemocap_blender_addon.core_functions.calculate_joint_angles.joint_angle_definitions import (
+    JointAngleDefinition,
+    RotationVectorDefinition,
+    ProjectedVectorDefinition,
+)
+
+# Define type aliases for better readability
+MarkerPositions = np.ndarray
+FrameIndex = int
+AngleValue = float
+
+
+class JointAngleCalculator:
+    def __init__(self, marker_names: List[str], marker_frame_xyz: MarkerPositions):
+        self.marker_names = marker_names
+        self.marker_frame_xyz = marker_frame_xyz
+        self.marker_name_to_index = {name: idx for idx, name in enumerate(marker_names)}
+        
+    def get_marker_position(self, frame: FrameIndex, marker_name: str) -> np.ndarray:
+        """Get the position of a marker in a specific frame."""
+        return self.marker_frame_xyz[frame, self.marker_name_to_index[marker_name]]
+    
+    def create_vector(self, origin_pos: np.ndarray, end_pos: np.ndarray) -> Vector:
+        """Create a Vector from two positions."""
+        return Vector(end_pos) - Vector(origin_pos)
+    
+    def calculate_reference_vector(self, frame: FrameIndex, definition: Dict) -> Vector:
+        """Calculate the reference vector based on its definition."""
+        vec_type = definition['type']
+        
+        if vec_type == 'vector':
+            origin_pos = self.get_marker_position(frame, definition['reference_vector_origin'])
+            end_pos = self.get_marker_position(frame, definition['reference_vector_end'])
+            return self.create_vector(origin_pos, end_pos)
+            
+        elif vec_type == 'crossproduct':
+            vec1 = self.create_vector(
+                self.get_marker_position(frame, definition['reference_cross_1_origin']),
+                self.get_marker_position(frame, definition['reference_cross_1_end'])
+            )
+            vec2 = self.create_vector(
+                self.get_marker_position(frame, definition['reference_cross_2_origin']),
+                self.get_marker_position(frame, definition['reference_cross_2_end'])
+            )
+            return vec1.cross(vec2)
+            
+        elif vec_type == 'doublecrossproduct':
+            vec1 = self.create_vector(
+                self.get_marker_position(frame, definition['reference_cross_1_origin']),
+                self.get_marker_position(frame, definition['reference_cross_1_end'])
+            )
+            vec2 = self.create_vector(
+                self.get_marker_position(frame, definition['reference_cross_2_origin']),
+                self.get_marker_position(frame, definition['reference_cross_2_end'])
+            )
+            vec3 = self.create_vector(
+                self.get_marker_position(frame, definition['reference_cross_3_origin']),
+                self.get_marker_position(frame, definition['reference_cross_3_end'])
+            )
+            return vec1.cross(vec2).cross(vec3)
+            
+        elif vec_type == 'average':
+            vec1 = self.create_vector(
+                self.get_marker_position(frame, definition['reference_average_1_origin']),
+                self.get_marker_position(frame, definition['reference_average_1_end'])
+            )
+            vec2 = self.create_vector(
+                self.get_marker_position(frame, definition['reference_average_2_origin']),
+                self.get_marker_position(frame, definition['reference_average_2_end'])
+            )
+            return (vec1 + vec2) / 2
+            
+        else:
+            raise ValueError(f"Invalid reference vector type: {vec_type}")
+    
+    def calculate_plane_axis(self, frame: FrameIndex, axis_def: Dict) -> Vector:
+        """Calculate a plane axis based on its definition."""
+        axis_type = axis_def['type']
+
+        if axis_type == 'vector':
+            origin_pos = self.get_marker_position(frame, axis_def['plane_axis_origin'])
+            end_pos = self.get_marker_position(frame, axis_def['plane_axis_end'])
+            return self.create_vector(origin_pos, end_pos).normalized()
+            
+        elif axis_type == 'crossproduct':
+            vec1 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_cross_1_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_cross_1_end'])
+            ).normalized()
+            vec2 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_cross_2_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_cross_2_end'])
+            ).normalized()
+            return vec1.cross(vec2).normalized()
+            
+        elif axis_type == 'doublecrossproduct':
+            vec1 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_cross_1_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_cross_1_end'])
+            ).normalized()
+            vec2 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_cross_2_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_cross_2_end'])
+            ).normalized()
+            vec3 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_cross_3_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_cross_3_end'])
+            ).normalized()
+            return vec1.cross(vec2).cross(vec3).normalized()
+            
+        elif axis_type == 'average':
+            vec1 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_average_1_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_average_1_end'])
+            ).normalized()
+            vec2 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_average_2_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_average_2_end'])
+            ).normalized()
+            return ((vec1 + vec2) / 2).normalized()
+            
+        elif axis_type == 'average_crossproduct':
+            vec1 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_average_1_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_average_1_end'])
+            ).normalized()
+            vec2 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_average_2_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_average_2_end'])
+            ).normalized()
+            avg = ((vec1 + vec2) / 2).normalized()
+            
+            vec3 = self.create_vector(
+                self.get_marker_position(frame, axis_def['plane_axis_cross_1_origin']),
+                self.get_marker_position(frame, axis_def['plane_axis_cross_1_end'])
+            ).normalized()
+            return avg.cross(vec3).normalized()
+            
+        else:
+            raise ValueError(f"Unsupported axis type: {axis_type}")
+    
+    def calculate_projected_vector(
+        self, 
+        frame: FrameIndex, 
+        projection_def: ProjectedVectorDefinition
+    ) -> Tuple[np.ndarray, Vector]:
+        """Calculate a projected vector and its plane normal."""
+        # Get the vector to project
+        proj_vec_origin = self.get_marker_position(frame, projection_def.origin)
+        proj_vec_end = self.get_marker_position(frame, projection_def.end)
+        vec_to_project = proj_vec_end - proj_vec_origin
+        
+        # Calculate plane axes
+        axis1 = self.calculate_plane_axis(frame, projection_def.projection_plane.axis1)
+        axis2 = self.calculate_plane_axis(frame, projection_def.projection_plane.axis2)
+        
+        # Define plane and project vector
+        plane_normal = axis1.cross(axis2).normalized()
+        vec_proj = vec_to_project - plane_normal * vec_to_project.dot(plane_normal)
+        
+        # Return projected position and plane normal
+        return (proj_vec_origin + vec_proj, plane_normal)
+    
+    def calculate_rotation_vector(
+        self, 
+        frame: FrameIndex, 
+        rotation_def: RotationVectorDefinition
+    ) -> Tuple[Vector, Optional[Vector]]:
+        """Calculate the rotation vector and optionally its plane normal."""
+        origin_pos = self.get_marker_position(frame, rotation_def.origin)
+        
+        if isinstance(rotation_def.end, str):
+            # Simple vector case
+            end_pos = self.get_marker_position(frame, rotation_def.end)
+            return (self.create_vector(origin_pos, end_pos), None)
+        else:
+            # Projected vector case
+            end_pos, plane_normal = self.calculate_projected_vector(frame, rotation_def.end)
+            return (self.create_vector(origin_pos, end_pos), plane_normal)
+    
+    def calculate_joint_angle(
+        self, 
+        frame: FrameIndex, 
+        angle_def: JointAngleDefinition
+    ) -> AngleValue:
+        """Calculate a single joint angle for a specific frame."""
+        # Calculate reference vector
+        reference_vector = self.calculate_reference_vector(frame, angle_def.reference_vector)
+        
+        # Calculate rotation vector and get plane normal if available
+        rotation_vector, rotation_plane_normal = self.calculate_rotation_vector(
+            frame, angle_def.rotation_vector
+        )
+        
+        # Calculate angle between vectors
+        angle = m.degrees(rotation_vector.angle(reference_vector))
+        
+        # Determine angle sign using cross product and plane normal
+        cross_product = reference_vector.cross(rotation_vector)
+        if rotation_plane_normal is None:
+            rotation_plane_normal = cross_product
+        
+        if cross_product.dot(rotation_plane_normal) < 0:
+            angle = -angle
+
+        # Add the zero offset angle
+        angle += angle_def.zero_offset
+            
+        return angle
 
 def calculate_joint_angles(
     output_path: str,
-    marker_names: list,
-    marker_frame_xyz: np.ndarray
-):
+    marker_names: List[str],
+    marker_frame_xyz: MarkerPositions,
+    joint_angles_definitions: Dict[str, JointAngleDefinition]
+) -> None:
+    """Main function to calculate all joint angles for all frames."""
     print("Calculating joint angles...")
-
-    angle_list = list(joint_angles.keys())
-    # Initialize an array to hold the angle values with nans
+    
+    # Initialize calculator and result array
+    calculator = JointAngleCalculator(marker_names, marker_frame_xyz)
+    angle_list = list(joint_angles_definitions.keys())
     angle_values = np.full((marker_frame_xyz.shape[0], len(angle_list)), np.nan)
-
-    for joint_angle in joint_angles:
-        for frame in range(marker_frame_xyz.shape[0]):
-
-            # Rotation plane normal to define rotation angle sign
-            rotation_plane_normal = None
-
-            # Get the reference vector definition
-            reference_vector_def = joint_angles[joint_angle]['reference_vector']
-
-            # Get the reference vector
-            if joint_angles[joint_angle]['reference_vector']['type'] == 'vector':
-                reference_vector_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_vector_origin'])]
-                reference_vector_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_vector_end'])]
-            
-                # Calculate the reference vector
-                reference_vector = Vector(reference_vector_end_position) - Vector(reference_vector_origin_position)
-
-            elif joint_angles[joint_angle]['reference_vector']['type'] == 'crossproduct':
-
-                cross_vector_1_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_1_origin'])]
-                cross_vector_1_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_1_end'])]
-                cross_vector_2_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_2_origin'])]
-                cross_vector_2_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_2_end'])]
-
-                # Calculate the cross product
-                cross_vector_1 = Vector(cross_vector_1_end_position) - Vector(cross_vector_1_origin_position)
-                cross_vector_2 = Vector(cross_vector_2_end_position) - Vector(cross_vector_2_origin_position)
-                #  Calculate the reference vector
-                reference_vector = cross_vector_1.cross(cross_vector_2)
-
-            elif joint_angles[joint_angle]['reference_vector']['type'] == 'doublecrossproduct':
-
-                cross_vector_1_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_1_origin'])]
-                cross_vector_1_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_1_end'])]
-                cross_vector_2_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_2_origin'])]
-                cross_vector_2_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_2_end'])]
-                cross_vector_3_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_3_origin'])]
-                cross_vector_3_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_cross_3_end'])]
-
-                # Calculate the cross product
-                cross_vector_1 = Vector(cross_vector_1_end_position) - Vector(cross_vector_1_origin_position)
-                cross_vector_2 = Vector(cross_vector_2_end_position) - Vector(cross_vector_2_origin_position)
-                cross_vector_3 = Vector(cross_vector_3_end_position) - Vector(cross_vector_3_origin_position)
-                # Calculate the reference vector
-                reference_vector = cross_vector_1.cross(cross_vector_2).cross(cross_vector_3)
-
-            elif joint_angles[joint_angle]['reference_vector']['type'] == 'average':
-
-                average_vector_1_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_average_1_origin'])]
-                average_vector_1_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_average_1_end'])]
-                average_vector_2_origin_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_average_2_origin'])]
-                average_vector_2_end_position = marker_frame_xyz[frame, marker_names.index(reference_vector_def['reference_average_2_end'])]
-
-                # Calculate the average vector
-                average_vector_1 = Vector(average_vector_1_end_position) - Vector(average_vector_1_origin_position)
-                average_vector_2 = Vector(average_vector_2_end_position) - Vector(average_vector_2_origin_position)
-                #  Calculate the reference vector
-                reference_vector = (average_vector_1 + average_vector_2) / 2
-
-            else:
-                raise ValueError(f"Invalid reference vector type: {joint_angles[joint_angle]['reference_vector']['type']}")
-           
-
-            # Get the rotation vector definition
-            rotation_vector_def = joint_angles[joint_angle]['rotation_vector']
-
-            # Get the rotation marker positions
-            rotation_vector_origin_position = marker_frame_xyz[
-                frame, marker_names.index(rotation_vector_def['rotation_vector_origin'])
-            ]
-
-            # If the rotation_vector_end is just a marker name string
-            # then get the vector directly. If not, get the vector as
-            # the projection on the projection plane
-            if isinstance(rotation_vector_def['rotation_vector_end'], str):
-                rotation_vector_end_position = marker_frame_xyz[
-                    frame, marker_names.index(rotation_vector_def['rotation_vector_end'])
-                ]
-
-            else:
-                # Extract definitions
-                end_def = joint_angles[joint_angle]['rotation_vector']['rotation_vector_end']
-
-                # Get projected vector
-                proj_vec_origin = marker_frame_xyz[frame, marker_names.index(end_def['projected_vector_origin'])]
-                proj_vec_end = marker_frame_xyz[frame, marker_names.index(end_def['projected_vector_end'])]
-                
-                vec_to_project = proj_vec_end - proj_vec_origin
-
-                # --- Compute plane axes ---
-
-                # Axis 1
-                axis1_def = end_def['projection_plane']['plane_axis_1']
-
-                if axis1_def['type'] == 'vector':
-                    axis1_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_origin'])]
-                    axis1_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_end'])]
-
-                    axis1 = (Vector(axis1_end) - Vector(axis1_origin)).normalized()
-
-                elif axis1_def['type'] == 'crossproduct':
-                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_1_origin'])]
-                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_1_end'])]
-                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_2_origin'])]
-                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_2_end'])]
-
-                    vec1 = Vector(cp1_end) - Vector(cp1_origin)
-                    vec2 = Vector(cp2_end) - Vector(cp2_origin)
-
-                    axis1 = vec1.cross(vec2).normalized()
-
-                elif axis1_def['type'] == 'doublecrossproduct':
-                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_1_origin'])]
-                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_1_end'])]
-                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_2_origin'])]
-                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_2_end'])]
-                    cp3_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_3_origin'])]
-                    cp3_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_cross_3_end'])]
-
-                    vec1 = Vector(cp1_end) - Vector(cp1_origin)
-                    vec2 = Vector(cp2_end) - Vector(cp2_origin)
-                    vec3 = Vector(cp3_end) - Vector(cp3_origin)
-
-                    axis1 = vec1.cross(vec2).cross(vec3).normalized()
-
-                elif axis1_def['type'] == 'average':
-                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_average_1_origin'])]
-                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_average_1_end'])]
-                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_average_2_origin'])]
-                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis1_def['plane_axis_1_average_2_end'])]
-
-                    vec1 = Vector(cp1_end) - Vector(cp1_origin)
-                    vec2 = Vector(cp2_end) - Vector(cp2_origin)
-
-                    axis1 = (vec1 + vec2) / 2
-
-                else:
-                    raise ValueError("Unsupported axis1 type")
-
-                # Axis 2
-                axis2_def = end_def['projection_plane']['plane_axis_2']
-                if axis2_def['type'] == 'vector':
-                    axis2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_origin'])]
-                    axis2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_end'])]
-
-                    axis2 = (Vector(axis2_end) - Vector(axis2_origin)).normalized()
-
-                elif axis2_def['type'] == 'crossproduct':
-                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_origin'])]
-                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_end'])]
-                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_2_origin'])]
-                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_2_end'])]
-
-                    vec1 = (Vector(cp1_end) - Vector(cp1_origin)).normalized()
-                    vec2 = (Vector(cp2_end) - Vector(cp2_origin)).normalized()
-
-                    axis2 = vec1.cross(vec2).normalized()
-
-                elif axis2_def['type'] == 'doublecrossproduct':
-                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_origin'])]
-                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_end'])]
-                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_2_origin'])]
-                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_2_end'])]
-                    cp3_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_3_origin'])]
-                    cp3_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_3_end'])]
-
-                    vec1 = (Vector(cp1_end) - Vector(cp1_origin)).normalized()
-                    vec2 = (Vector(cp2_end) - Vector(cp2_origin)).normalized()
-                    vec3 = (Vector(cp3_end) - Vector(cp3_origin)).normalized()
-
-                    axis2 = vec1.cross(vec2).cross(vec3).normalized()
-
-                elif axis2_def['type'] == 'average':
-                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_1_origin'])]
-                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_1_end'])]
-                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_2_origin'])]
-                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_2_end'])]
-
-                    vec1 = (Vector(cp1_end) - Vector(cp1_origin)).normalized()
-                    vec2 = (Vector(cp2_end) - Vector(cp2_origin)).normalized()
-
-                    axis2 = (vec1 + vec2) / 2
-
-                elif axis2_def['type'] == 'average_crossproduct':
-                    cp1_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_1_origin'])]
-                    cp1_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_1_end'])]
-                    cp2_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_2_origin'])]
-                    cp2_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_average_2_end'])]
-                    cp3_origin = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_origin'])]
-                    cp3_end = marker_frame_xyz[frame, marker_names.index(axis2_def['plane_axis_2_cross_1_end'])]
-
-                    vec1 = (Vector(cp1_end) - Vector(cp1_origin)).normalized()
-                    vec2 = (Vector(cp2_end) - Vector(cp2_origin)).normalized()
-                    avg = (vec1 + vec2) / 2
-
-                    vec3 = (Vector(cp3_end) - Vector(cp3_origin)).normalized()
-
-                    axis2 = avg.cross(vec3).normalized()                    
-
-                else:
-                    raise ValueError("Unsupported axis2 type")
-
-                # --- Project vector onto plane ---
-
-                # Define plane
-                plane_normal = axis1.cross(axis2).normalized()
-                vec_proj = vec_to_project - plane_normal * vec_to_project.dot(plane_normal)
-
-                # Final projected position
-                rotation_vector_end_position = proj_vec_origin + vec_proj
-
-                # Assign the plane normal as rotation_plane_normal
-                rotation_plane_normal = plane_normal
-
-
-            # Calculate the rotation vector
-            rotation_vector = Vector(rotation_vector_end_position) - Vector(rotation_vector_origin_position)
-
-            # Get the cross product of the reference vector and the rotation vector
-            cross_product = reference_vector.cross(rotation_vector)
-
-            # In case rotation_plane_normal is None then set it as the cross product
-            if rotation_plane_normal is None:
-                rotation_plane_normal = cross_product
-
-            rotation_angle = m.degrees(rotation_vector.angle(reference_vector))
-
-            if cross_product.dot(rotation_plane_normal) < 0:
-                rotation_angle = -rotation_angle
-
-            # Store the angle value in the angle_values array
-            angle_values[frame, angle_list.index(joint_angle)] = rotation_angle
-
-    # Write the angle values to a csv file. Use the angle_list as the header
+    
+    # Calculate angles for each frame and joint
+    for frame in range(marker_frame_xyz.shape[0]):
+        for joint_angle_name, angle_def in joint_angles_definitions.items():
+            try:
+                angle = calculator.calculate_joint_angle(frame, angle_def)
+                angle_values[frame, angle_list.index(joint_angle_name)] = angle
+            except Exception as e:
+                print(f"Error calculating {joint_angle_name} for frame {frame}: {str(e)}")
+                continue
+    
+    # Save results to CSV
     np.savetxt(
         output_path,
         angle_values,
@@ -258,4 +247,5 @@ def calculate_joint_angles(
         fmt='%.8f',
     )
 
-    return
+    # Save results to a numpy file
+    np.save(output_path.replace('.csv', '.npy'), angle_values) 

--- a/ajc27_freemocap_blender_addon/core_functions/calculate_joint_angles/joint_angle_definitions.py
+++ b/ajc27_freemocap_blender_addon/core_functions/calculate_joint_angles/joint_angle_definitions.py
@@ -1,658 +1,637 @@
-joint_angles = {
-    'left_elbow_extension_flexion' : {
-        'joint_center': 'left_elbow',
-        'reference_vector': {
+from dataclasses import dataclass
+from typing import Dict, Union
+
+@dataclass
+class ProjectionPlaneDefinition:
+    axis1: Dict
+    axis2: Dict
+
+@dataclass
+class ProjectedVectorDefinition:
+    origin: str
+    end: str
+    projection_plane: ProjectionPlaneDefinition
+
+@dataclass
+class RotationVectorDefinition:
+    origin: str
+    end: Union[str, ProjectedVectorDefinition]
+
+@dataclass
+class JointAngleDefinition:
+    joint_center: str
+    reference_vector: Dict
+    rotation_vector: RotationVectorDefinition
+    zero_offset: float = 0.0 # value in degrees to offset the angle calculation in some cases like ankle angles
+
+joint_angles_definitions = {
+    'left_elbow_extension_flexion': JointAngleDefinition(
+        joint_center='left_elbow',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'left_shoulder',
             'reference_vector_end': 'left_elbow',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_elbow',
-            'rotation_vector_end': 'left_wrist',
-        },
-    },
-    'left_shoulder_extension_flexion' : {
-        'joint_center': 'left_shoulder',
-        'reference_vector': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_elbow',
+            end='left_wrist'
+        )
+    ),
+    'left_shoulder_extension_flexion': JointAngleDefinition(
+        joint_center='left_shoulder',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'neck_center',
             'reference_vector_end': 'trunk_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_shoulder',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'left_shoulder',
-                'projected_vector_end': 'left_elbow',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_shoulder',
+            end=ProjectedVectorDefinition(
+                origin='left_shoulder',
+                end='left_elbow',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'neck_center',
-                        'plane_axis_1_end': 'trunk_center',
+                        'plane_axis_origin': 'neck_center',
+                        'plane_axis_end': 'trunk_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'crossproduct',
-                        'plane_axis_2_cross_1_origin': 'neck_center',
-                        'plane_axis_2_cross_1_end': 'trunk_center',
-                        'plane_axis_2_cross_2_origin': 'neck_center',
-                        'plane_axis_2_cross_2_end': 'left_shoulder',
+                        'plane_axis_cross_1_origin': 'neck_center',
+                        'plane_axis_cross_1_end': 'trunk_center',
+                        'plane_axis_cross_2_origin': 'neck_center',
+                        'plane_axis_cross_2_end': 'left_shoulder',
                     },
-                }
-            }
-        },
-    },
-    'left_shoulder_abduction_adduction': {
-        'joint_center': 'left_shoulder',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'left_shoulder_abduction_adduction': JointAngleDefinition(
+        joint_center='left_shoulder',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'neck_center',
             'reference_vector_end': 'trunk_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_shoulder',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'left_shoulder',
-                'projected_vector_end': 'left_elbow',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_shoulder',
+            end=ProjectedVectorDefinition(
+                origin='left_shoulder',
+                end='left_elbow',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'neck_center',
-                        'plane_axis_1_end': 'trunk_center',
+                        'plane_axis_origin': 'neck_center',
+                        'plane_axis_end': 'trunk_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'neck_center',
-                        'plane_axis_2_end': 'left_shoulder',
+                        'plane_axis_origin': 'neck_center',
+                        'plane_axis_end': 'left_shoulder',
                     },
-                }
-            }
-        },
-    },
-    'right_elbow_extension_flexion' : {
-        'joint_center': 'right_elbow',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'right_elbow_extension_flexion': JointAngleDefinition(
+        joint_center='right_elbow',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'right_shoulder',
             'reference_vector_end': 'right_elbow',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_elbow',
-            'rotation_vector_end': 'right_wrist',
-        },
-    },
-    'right_shoulder_extension_flexion' : {
-        'joint_center': 'right_shoulder',
-        'reference_vector': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_elbow',
+            end='right_wrist'
+        )
+    ),
+    'right_shoulder_extension_flexion': JointAngleDefinition(
+        joint_center='right_shoulder',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'neck_center',
             'reference_vector_end': 'trunk_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_shoulder',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'right_shoulder',
-                'projected_vector_end': 'right_elbow',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_shoulder',
+            end=ProjectedVectorDefinition(
+                origin='right_shoulder',
+                end='right_elbow',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'neck_center',
-                        'plane_axis_1_end': 'trunk_center',
+                        'plane_axis_origin': 'neck_center',
+                        'plane_axis_end': 'trunk_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'crossproduct',
-                        'plane_axis_2_cross_1_origin': 'neck_center',
-                        'plane_axis_2_cross_1_end': 'right_shoulder',
-                        'plane_axis_2_cross_2_origin': 'neck_center',
-                        'plane_axis_2_cross_2_end': 'trunk_center',
+                        'plane_axis_cross_1_origin': 'neck_center',
+                        'plane_axis_cross_1_end': 'right_shoulder',
+                        'plane_axis_cross_2_origin': 'neck_center',
+                        'plane_axis_cross_2_end': 'trunk_center',
                     },
-                }
-            }
-        },
-    },
-    'right_shoulder_abduction_adduction': {
-        'joint_center': 'right_shoulder',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'right_shoulder_abduction_adduction': JointAngleDefinition(
+        joint_center='right_shoulder',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'neck_center',
             'reference_vector_end': 'trunk_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_shoulder',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'right_shoulder',
-                'projected_vector_end': 'right_elbow',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_shoulder',
+            end=ProjectedVectorDefinition(
+                origin='right_shoulder',
+                end='right_elbow',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'neck_center',
-                        'plane_axis_1_end': 'trunk_center',
+                        'plane_axis_origin': 'neck_center',
+                        'plane_axis_end': 'trunk_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'neck_center',
-                        'plane_axis_2_end': 'right_shoulder',
+                        'plane_axis_origin': 'neck_center',
+                        'plane_axis_end': 'right_shoulder',
                     },
-                }
-            }
-        },
-    },
-    'left_knee_extension_flexion' : {
-        'joint_center': 'left_knee',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'left_knee_extension_flexion': JointAngleDefinition(
+        joint_center='left_knee',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'left_hip',
             'reference_vector_end': 'left_knee',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_knee',
-            'rotation_vector_end': 'left_ankle',
-        },
-    },
-    'left_hip_extension_flexion' : {
-        'joint_center': 'left_hip',
-        'reference_vector': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_knee',
+            end='left_ankle'
+        )
+    ),
+    'left_hip_extension_flexion': JointAngleDefinition(
+        joint_center='left_hip',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'trunk_center',
             'reference_vector_end': 'hips_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_hip',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'left_hip',
-                'projected_vector_end': 'left_knee',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_hip',
+            end=ProjectedVectorDefinition(
+                origin='left_hip',
+                end='left_knee',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'trunk_center',
-                        'plane_axis_1_end': 'hips_center',
+                        'plane_axis_origin': 'trunk_center',
+                        'plane_axis_end': 'hips_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'crossproduct',
-                        'plane_axis_2_cross_1_origin': 'trunk_center',
-                        'plane_axis_2_cross_1_end': 'hips_center',
-                        'plane_axis_2_cross_2_origin': 'hips_center',
-                        'plane_axis_2_cross_2_end': 'left_hip',
+                        'plane_axis_cross_1_origin': 'trunk_center',
+                        'plane_axis_cross_1_end': 'hips_center',
+                        'plane_axis_cross_2_origin': 'hips_center',
+                        'plane_axis_cross_2_end': 'left_hip',
                     },
-                }
-            }
-        },
-    },
-    'left_hip_abduction_adduction': {
-        'joint_center': 'left_hip',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'left_hip_abduction_adduction': JointAngleDefinition(
+        joint_center='left_hip',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'trunk_center',
             'reference_vector_end': 'hips_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_hip',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'left_hip',
-                'projected_vector_end': 'left_knee',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_hip',
+            end=ProjectedVectorDefinition(
+                origin='left_hip',
+                end='left_knee',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'trunk_center',
-                        'plane_axis_1_end': 'hips_center',
+                        'plane_axis_origin': 'trunk_center',
+                        'plane_axis_end': 'hips_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'hips_center',
-                        'plane_axis_2_end': 'left_hip',
+                        'plane_axis_origin': 'hips_center',
+                        'plane_axis_end': 'left_hip',
                     },
-                }
-            }
-        },
-    },
-    # 'left_hip_rotation': {
-    #     'joint_center': 'left_hip',
-    #     'reference_vector': {
-    #         'type': 'crossproduct',
-    #         'reference_cross_1_origin': 'left_hip',
-    #         'reference_cross_1_end': 'left_knee',
-    #         'reference_cross_2_origin': 'hips_center',
-    #         'reference_cross_2_end': 'left_hip',
-    #     },
-    #     'rotation_vector': {
-    #         'rotation_vector_origin': 'left_hip',
-    #         'rotation_vector_end': {
-                  ## TODO: Improve the projection logic so it can work
-                  ##       with a projected vector that it doesn't have
-                  ##       the same origin as the rotion vector. Like
-                  ##       the ankle-foot_index vector in this case
-    #             'projected_vector_origin': 'left_hip',
-    #             'projected_vector_end': 'left_foot_index',
-    #             'projection_plane': {
-    #                 'plane_axis_1': {
-    #                     'type': 'vector',
-    #                     'plane_axis_1_origin': 'hips_center',
-    #                     'plane_axis_1_end': 'left_hip',
-    #                 },
-    #                 'plane_axis_2': {
-    #                     'type': 'crossproduct',
-    #                     'plane_axis_2_cross_1_origin': 'left_hip',
-    #                     'plane_axis_2_cross_1_end': 'left_knee',
-    #                     'plane_axis_2_cross_2_origin': 'hips_center',
-    #                     'plane_axis_2_cross_2_end': 'left_hip',
-    #                 },
-    #             }
-    #         }
-    #     },
-    # },
-    'right_knee_extension_flexion' : {
-        'joint_center': 'right_knee',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'right_knee_extension_flexion': JointAngleDefinition(
+        joint_center='right_knee',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'right_hip',
             'reference_vector_end': 'right_knee',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_knee',
-            'rotation_vector_end': 'right_ankle',
-        },
-    },
-    'right_hip_extension_flexion' : {
-        'joint_center': 'right_hip',
-        'reference_vector': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_knee',
+            end='right_ankle'
+        )
+    ),
+    'right_hip_extension_flexion': JointAngleDefinition(
+        joint_center='right_hip',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'trunk_center',
             'reference_vector_end': 'hips_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_hip',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'right_hip',
-                'projected_vector_end': 'right_knee',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_hip',
+            end=ProjectedVectorDefinition(
+                origin='right_hip',
+                end='right_knee',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'trunk_center',
-                        'plane_axis_1_end': 'hips_center',
+                        'plane_axis_origin': 'trunk_center',
+                        'plane_axis_end': 'hips_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'crossproduct',
-                        'plane_axis_2_cross_1_origin': 'hips_center',
-                        'plane_axis_2_cross_1_end': 'right_hip',
-                        'plane_axis_2_cross_2_origin': 'trunk_center',
-                        'plane_axis_2_cross_2_end': 'hips_center',
+                        'plane_axis_cross_1_origin': 'hips_center',
+                        'plane_axis_cross_1_end': 'right_hip',
+                        'plane_axis_cross_2_origin': 'trunk_center',
+                        'plane_axis_cross_2_end': 'hips_center',
                     },
-                }
-            }
-        },
-    },
-    'right_hip_abduction_adduction': {
-        'joint_center': 'right_hip',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'right_hip_abduction_adduction': JointAngleDefinition(
+        joint_center='right_hip',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'trunk_center',
             'reference_vector_end': 'hips_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_hip',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'right_hip',
-                'projected_vector_end': 'right_knee',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_hip',
+            end=ProjectedVectorDefinition(
+                origin='right_hip',
+                end='right_knee',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'trunk_center',
-                        'plane_axis_1_end': 'hips_center',
+                        'plane_axis_origin': 'trunk_center',
+                        'plane_axis_end': 'hips_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'hips_center',
-                        'plane_axis_2_end': 'right_hip',
+                        'plane_axis_origin': 'hips_center',
+                        'plane_axis_end': 'right_hip',
                     },
-                }
-            }
-        },
-    },
-    'neck_extension_flexion' : {
-        'joint_center': 'neck_center',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'neck_extension_flexion': JointAngleDefinition(
+        joint_center='neck_center',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'trunk_center',
             'reference_vector_end': 'neck_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'neck_center',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'neck_center',
-                'projected_vector_end': 'head_center',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='neck_center',
+            end=ProjectedVectorDefinition(
+                origin='neck_center',
+                end='head_center',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'trunk_center',
-                        'plane_axis_1_end': 'neck_center',
+                        'plane_axis_origin': 'trunk_center',
+                        'plane_axis_end': 'neck_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'crossproduct',
-                        'plane_axis_2_cross_1_origin': 'trunk_center',
-                        'plane_axis_2_cross_1_end': 'neck_center',
-                        'plane_axis_2_cross_2_origin': 'neck_center',
-                        'plane_axis_2_cross_2_end': 'right_shoulder',
+                        'plane_axis_cross_1_origin': 'trunk_center',
+                        'plane_axis_cross_1_end': 'neck_center',
+                        'plane_axis_cross_2_origin': 'neck_center',
+                        'plane_axis_cross_2_end': 'right_shoulder',
                     },
-                }
-            }
-        },
-    },
-    'neck_lateral_flexion': {
-        'joint_center': 'neck_center',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'neck_lateral_flexion': JointAngleDefinition(
+        joint_center='neck_center',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'trunk_center',
             'reference_vector_end': 'neck_center',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'neck_center',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'neck_center',
-                'projected_vector_end': 'head_center',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='neck_center',
+            end=ProjectedVectorDefinition(
+                origin='neck_center',
+                end='head_center',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'trunk_center',
-                        'plane_axis_1_end': 'neck_center',
+                        'plane_axis_origin': 'trunk_center',
+                        'plane_axis_end': 'neck_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'neck_center',
-                        'plane_axis_2_end': 'left_shoulder',
+                        'plane_axis_origin': 'neck_center',
+                        'plane_axis_end': 'left_shoulder',
                     },
-                }
-            }
-        },
-    },
-    'neck_rotation': {
-        'joint_center': 'neck_center',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'neck_rotation': JointAngleDefinition(
+        joint_center='neck_center',
+        reference_vector={
             'type': 'crossproduct',
             'reference_cross_1_origin': 'neck_center',
             'reference_cross_1_end': 'head_center',
             'reference_cross_2_origin': 'neck_center',
             'reference_cross_2_end': 'right_shoulder',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'neck_center',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'neck_center',
-                'projected_vector_end': 'nose',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='neck_center',
+            end=ProjectedVectorDefinition(
+                origin='neck_center',
+                end='nose',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'doublecrossproduct',
-                        'plane_axis_1_cross_1_origin': 'neck_center',
-                        'plane_axis_1_cross_1_end': 'head_center',
-                        'plane_axis_1_cross_2_origin': 'neck_center',
-                        'plane_axis_1_cross_2_end': 'right_shoulder',
-                        'plane_axis_1_cross_3_origin': 'neck_center',
-                        'plane_axis_1_cross_3_end': 'head_center',
+                        'plane_axis_cross_1_origin': 'neck_center',
+                        'plane_axis_cross_1_end': 'head_center',
+                        'plane_axis_cross_2_origin': 'neck_center',
+                        'plane_axis_cross_2_end': 'right_shoulder',
+                        'plane_axis_cross_3_origin': 'neck_center',
+                        'plane_axis_cross_3_end': 'head_center',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'crossproduct',
-                        'plane_axis_2_cross_1_origin': 'neck_center',
-                        'plane_axis_2_cross_1_end': 'right_shoulder',
-                        'plane_axis_2_cross_2_origin': 'neck_center',
-                        'plane_axis_2_cross_2_end': 'head_center',
+                        'plane_axis_cross_1_origin': 'neck_center',
+                        'plane_axis_cross_1_end': 'right_shoulder',
+                        'plane_axis_cross_2_origin': 'neck_center',
+                        'plane_axis_cross_2_end': 'head_center',
                     },
-                }
-            }
-        },
-    },
-    # TODO: Define a better reference vector and rotation plane because
-    # when the leg is fully extended the thigh and shin bones might form
-    # unwanted angles. The most obvious choice is to just use knee-ankle
-    # and ankle-foot_index, but that ommits the other ankle rotations
-    # TODO: Add an offset to the angle so it is 0º when it is on the a 
-    # standing straight pose
-    'left_ankle_dorsiflexion_plantarflexion' : {
-        'joint_center': 'left_ankle',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'left_ankle_dorsiflexion_plantarflexion': JointAngleDefinition(
+        joint_center='left_ankle',
+        reference_vector={
             'type': 'doublecrossproduct',
-                'reference_cross_1_origin': 'left_knee',
-                'reference_cross_1_end': 'left_ankle',
-                'reference_cross_2_origin': 'left_ankle',
-                'reference_cross_2_end': 'left_foot_index',
-                'reference_cross_3_origin': 'left_knee',
-                'reference_cross_3_end': 'left_ankle',
+            'reference_cross_1_origin': 'left_knee',
+            'reference_cross_1_end': 'left_ankle',
+            'reference_cross_2_origin': 'left_ankle',
+            'reference_cross_2_end': 'left_foot_index',
+            'reference_cross_3_origin': 'left_knee',
+            'reference_cross_3_end': 'left_ankle',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_ankle',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'left_ankle',
-                'projected_vector_end': 'left_foot_index',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_ankle',
+            end=ProjectedVectorDefinition(
+                origin='left_ankle',
+                end='left_foot_index',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'left_knee',
-                        'plane_axis_1_end': 'left_ankle',
+                        'plane_axis_origin': 'left_knee',
+                        'plane_axis_end': 'left_ankle',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'left_knee',
-                        'plane_axis_2_end': 'left_foot_index',
+                        'plane_axis_origin': 'left_knee',
+                        'plane_axis_end': 'left_foot_index',
                     },
-                }
-            }
-        },
-    },
-    'left_ankle_inversion_eversion' : {
-        'joint_center': 'left_ankle',
-        'reference_vector': {
+                )
+            )
+        ),
+        zero_offset=18.0  # Offset to make the zero value when standing still
+    ),
+    'left_ankle_inversion_eversion': JointAngleDefinition(
+        joint_center='left_ankle',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'left_knee',
             'reference_vector_end': 'left_ankle',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_ankle',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'left_ankle',
-                'projected_vector_end': 'left_heel',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_ankle',
+            end=ProjectedVectorDefinition(
+                origin='left_ankle',
+                end='left_heel',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'crossproduct',
-                        'plane_axis_1_cross_1_origin': 'left_hip',
-                        'plane_axis_1_cross_1_end': 'left_knee',
-                        'plane_axis_1_cross_2_origin': 'left_knee',
-                        'plane_axis_1_cross_2_end': 'left_ankle',
+                        'plane_axis_cross_1_origin': 'left_hip',
+                        'plane_axis_cross_1_end': 'left_knee',
+                        'plane_axis_cross_2_origin': 'left_knee',
+                        'plane_axis_cross_2_end': 'left_ankle',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'left_knee',
-                        'plane_axis_2_end': 'left_ankle',
+                        'plane_axis_origin': 'left_knee',
+                        'plane_axis_end': 'left_ankle',
                     },
-                }
-            }
-        },
-    },
-    'right_ankle_dorsiflexion_plantarflexion' : {
-        'joint_center': 'right_ankle',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'right_ankle_dorsiflexion_plantarflexion': JointAngleDefinition(
+        joint_center='right_ankle',
+        reference_vector={
             'type': 'doublecrossproduct',
-                'reference_cross_1_origin': 'right_knee',
-                'reference_cross_1_end': 'right_ankle',
-                'reference_cross_2_origin': 'right_ankle',
-                'reference_cross_2_end': 'right_foot_index',
-                'reference_cross_3_origin': 'right_knee',
-                'reference_cross_3_end': 'right_ankle',
+            'reference_cross_1_origin': 'right_knee',
+            'reference_cross_1_end': 'right_ankle',
+            'reference_cross_2_origin': 'right_ankle',
+            'reference_cross_2_end': 'right_foot_index',
+            'reference_cross_3_origin': 'right_knee',
+            'reference_cross_3_end': 'right_ankle',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_ankle',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'right_ankle',
-                'projected_vector_end': 'right_foot_index',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_ankle',
+            end=ProjectedVectorDefinition(
+                origin='right_ankle',
+                end='right_foot_index',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'right_knee',
-                        'plane_axis_1_end': 'right_ankle',
+                        'plane_axis_origin': 'right_knee',
+                        'plane_axis_end': 'right_ankle',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'right_knee',
-                        'plane_axis_2_end': 'right_foot_index',
+                        'plane_axis_origin': 'right_knee',
+                        'plane_axis_end': 'right_foot_index',
                     },
-                }
-            }
-        },
-    },
-    'right_ankle_inversion_eversion' : {
-        'joint_center': 'right_ankle',
-        'reference_vector': {
+                )
+            )
+        ),
+        zero_offset=18.0  # Offset to make the zero value when standing still
+    ),
+    'right_ankle_inversion_eversion': JointAngleDefinition(
+        joint_center='right_ankle',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'right_knee',
             'reference_vector_end': 'right_ankle',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_ankle',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'right_ankle',
-                'projected_vector_end': 'right_heel',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_ankle',
+            end=ProjectedVectorDefinition(
+                origin='right_ankle',
+                end='right_heel',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'right_knee',
-                        'plane_axis_1_end': 'right_ankle',
+                        'plane_axis_origin': 'right_knee',
+                        'plane_axis_end': 'right_ankle',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'crossproduct',
-                        'plane_axis_2_cross_1_origin': 'right_hip',
-                        'plane_axis_2_cross_1_end': 'right_knee',
-                        'plane_axis_2_cross_2_origin': 'right_knee',
-                        'plane_axis_2_cross_2_end': 'right_ankle',
+                        'plane_axis_cross_1_origin': 'right_hip',
+                        'plane_axis_cross_1_end': 'right_knee',
+                        'plane_axis_cross_2_origin': 'right_knee',
+                        'plane_axis_cross_2_end': 'right_ankle',
                     },
-                }
-            }
-        },
-    },
-    # TODO: Find a better way to define the reference vector. As the pelvis
-    # is only defined by two markers, it can be determined what is its
-    # rotation in the Sagittal plane. The approach to use the average of the 
-    # two thighs is an approximation when both legs are rotated equally
-    # like when standing still.
-    'spine_extension_flexion' : {
-        'joint_center': 'hips_center',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'spine_extension_flexion': JointAngleDefinition(
+        joint_center='hips_center',
+        reference_vector={
             'type': 'average',
             'reference_average_1_origin': 'left_knee',
             'reference_average_1_end': 'left_hip',
             'reference_average_2_origin': 'right_knee',
             'reference_average_2_end': 'right_hip',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'hips_center',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'hips_center',
-                'projected_vector_end': 'trunk_center',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='hips_center',
+            end=ProjectedVectorDefinition(
+                origin='hips_center',
+                end='trunk_center',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'average',
-                        'plane_axis_1_average_1_origin': 'left_knee',
-                        'plane_axis_1_average_1_end': 'left_hip',
-                        'plane_axis_1_average_2_origin': 'right_knee',
-                        'plane_axis_1_average_2_end': 'right_hip',
+                        'plane_axis_average_1_origin': 'left_knee',
+                        'plane_axis_average_1_end': 'left_hip',
+                        'plane_axis_average_2_origin': 'right_knee',
+                        'plane_axis_average_2_end': 'right_hip',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'average_crossproduct',
-                        'plane_axis_2_average_1_origin': 'left_knee',
-                        'plane_axis_2_average_1_end': 'left_hip',
-                        'plane_axis_2_average_2_origin': 'right_knee',
-                        'plane_axis_2_average_2_end': 'right_hip',
-                        'plane_axis_2_cross_1_origin': 'hips_center',
-                        'plane_axis_2_cross_1_end': 'right_hip',                        
+                        'plane_axis_average_1_origin': 'left_knee',
+                        'plane_axis_average_1_end': 'left_hip',
+                        'plane_axis_average_2_origin': 'right_knee',
+                        'plane_axis_average_2_end': 'right_hip',
+                        'plane_axis_cross_1_origin': 'hips_center',
+                        'plane_axis_cross_1_end': 'right_hip',
                     },
-                }
-            }
-        },
-    },
-    # TODO: Same thing as spine flexion extension reference vector
-    'spine_lateral_flexion' : {
-        'joint_center': 'hips_center',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'spine_lateral_flexion': JointAngleDefinition(
+        joint_center='hips_center',
+        reference_vector={
             'type': 'average',
             'reference_average_1_origin': 'left_knee',
             'reference_average_1_end': 'left_hip',
             'reference_average_2_origin': 'right_knee',
             'reference_average_2_end': 'right_hip',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'hips_center',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'hips_center',
-                'projected_vector_end': 'trunk_center',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='hips_center',
+            end=ProjectedVectorDefinition(
+                origin='hips_center',
+                end='trunk_center',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'hips_center',
-                        'plane_axis_1_end': 'left_hip',   
+                        'plane_axis_origin': 'hips_center',
+                        'plane_axis_end': 'left_hip',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'average',
-                        'plane_axis_2_average_1_origin': 'left_knee',
-                        'plane_axis_2_average_1_end': 'left_hip',
-                        'plane_axis_2_average_2_origin': 'right_knee',
-                        'plane_axis_2_average_2_end': 'right_hip',
+                        'plane_axis_average_1_origin': 'left_knee',
+                        'plane_axis_average_1_end': 'left_hip',
+                        'plane_axis_average_2_origin': 'right_knee',
+                        'plane_axis_average_2_end': 'right_hip',
                     },
-                }
-            }
-        },
-    },
-    # TODO: Check the constraints of the hand. Mediapipe body hand markers
-    # and hand markers are not aligned. Probably placed them at average position?
-    'left_hand_extension_flexion' : {
-        'joint_center': 'left_wrist',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'left_hand_extension_flexion': JointAngleDefinition(
+        joint_center='left_wrist',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'left_elbow',
             'reference_vector_end': 'left_wrist',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'left_wrist',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'left_wrist',
-                'projected_vector_end': 'left_hand_middle',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='left_wrist',
+            end=ProjectedVectorDefinition(
+                origin='left_wrist',
+                end='left_hand_middle',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'vector',
-                        'plane_axis_1_origin': 'left_elbow',
-                        'plane_axis_1_end': 'left_wrist',   
+                        'plane_axis_origin': 'left_elbow',
+                        'plane_axis_end': 'left_wrist',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'crossproduct',
-                        'plane_axis_2_cross_1_origin': 'left_elbow',
-                        'plane_axis_2_cross_1_end': 'left_wrist',
-                        'plane_axis_2_cross_2_origin': 'left_wrist',
-                        'plane_axis_2_cross_2_end': 'left_hand_thumb_cmc',
+                        'plane_axis_cross_1_origin': 'left_elbow',
+                        'plane_axis_cross_1_end': 'left_wrist',
+                        'plane_axis_cross_2_origin': 'left_wrist',
+                        'plane_axis_cross_2_end': 'left_hand_thumb_cmc',
                     },
-                }
-            }
-        },
-    },
-    'right_hand_extension_flexion' : {
-        'joint_center': 'right_wrist',
-        'reference_vector': {
+                )
+            )
+        )
+    ),
+    'right_hand_extension_flexion': JointAngleDefinition(
+        joint_center='right_wrist',
+        reference_vector={
             'type': 'vector',
             'reference_vector_origin': 'right_elbow',
             'reference_vector_end': 'right_wrist',
         },
-        'rotation_vector': {
-            'rotation_vector_origin': 'right_wrist',
-            'rotation_vector_end': {
-                'projected_vector_origin': 'right_wrist',
-                'projected_vector_end': 'right_hand_middle',
-                'projection_plane': {
-                    'plane_axis_1': {
+        rotation_vector=RotationVectorDefinition(
+            origin='right_wrist',
+            end=ProjectedVectorDefinition(
+                origin='right_wrist',
+                end='right_hand_middle',
+                projection_plane=ProjectionPlaneDefinition(
+                    axis1={
                         'type': 'crossproduct',
-                        'plane_axis_1_cross_1_origin': 'right_elbow',
-                        'plane_axis_1_cross_1_end': 'right_wrist',
-                        'plane_axis_1_cross_2_origin': 'right_wrist',
-                        'plane_axis_1_cross_2_end': 'right_hand_thumb_cmc',
+                        'plane_axis_cross_1_origin': 'right_elbow',
+                        'plane_axis_cross_1_end': 'right_wrist',
+                        'plane_axis_cross_2_origin': 'right_wrist',
+                        'plane_axis_cross_2_end': 'right_hand_thumb_cmc',
                     },
-                    'plane_axis_2': {
+                    axis2={
                         'type': 'vector',
-                        'plane_axis_2_origin': 'right_elbow',
-                        'plane_axis_2_end': 'right_wrist',
+                        'plane_axis_origin': 'right_elbow',
+                        'plane_axis_end': 'right_wrist',
                     },
-                }
-            }
-        },
-    },
+                )
+            )
+        )
+    ),
 }

--- a/ajc27_freemocap_blender_addon/core_functions/calculate_joint_angles/joint_angle_definitions.py
+++ b/ajc27_freemocap_blender_addon/core_functions/calculate_joint_angles/joint_angle_definitions.py
@@ -1,0 +1,658 @@
+joint_angles = {
+    'left_elbow_extension_flexion' : {
+        'joint_center': 'left_elbow',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'left_shoulder',
+            'reference_vector_end': 'left_elbow',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_elbow',
+            'rotation_vector_end': 'left_wrist',
+        },
+    },
+    'left_shoulder_extension_flexion' : {
+        'joint_center': 'left_shoulder',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'neck_center',
+            'reference_vector_end': 'trunk_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_shoulder',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'left_shoulder',
+                'projected_vector_end': 'left_elbow',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'neck_center',
+                        'plane_axis_1_end': 'trunk_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'crossproduct',
+                        'plane_axis_2_cross_1_origin': 'neck_center',
+                        'plane_axis_2_cross_1_end': 'trunk_center',
+                        'plane_axis_2_cross_2_origin': 'neck_center',
+                        'plane_axis_2_cross_2_end': 'left_shoulder',
+                    },
+                }
+            }
+        },
+    },
+    'left_shoulder_abduction_adduction': {
+        'joint_center': 'left_shoulder',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'neck_center',
+            'reference_vector_end': 'trunk_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_shoulder',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'left_shoulder',
+                'projected_vector_end': 'left_elbow',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'neck_center',
+                        'plane_axis_1_end': 'trunk_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'neck_center',
+                        'plane_axis_2_end': 'left_shoulder',
+                    },
+                }
+            }
+        },
+    },
+    'right_elbow_extension_flexion' : {
+        'joint_center': 'right_elbow',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'right_shoulder',
+            'reference_vector_end': 'right_elbow',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_elbow',
+            'rotation_vector_end': 'right_wrist',
+        },
+    },
+    'right_shoulder_extension_flexion' : {
+        'joint_center': 'right_shoulder',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'neck_center',
+            'reference_vector_end': 'trunk_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_shoulder',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'right_shoulder',
+                'projected_vector_end': 'right_elbow',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'neck_center',
+                        'plane_axis_1_end': 'trunk_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'crossproduct',
+                        'plane_axis_2_cross_1_origin': 'neck_center',
+                        'plane_axis_2_cross_1_end': 'right_shoulder',
+                        'plane_axis_2_cross_2_origin': 'neck_center',
+                        'plane_axis_2_cross_2_end': 'trunk_center',
+                    },
+                }
+            }
+        },
+    },
+    'right_shoulder_abduction_adduction': {
+        'joint_center': 'right_shoulder',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'neck_center',
+            'reference_vector_end': 'trunk_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_shoulder',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'right_shoulder',
+                'projected_vector_end': 'right_elbow',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'neck_center',
+                        'plane_axis_1_end': 'trunk_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'neck_center',
+                        'plane_axis_2_end': 'right_shoulder',
+                    },
+                }
+            }
+        },
+    },
+    'left_knee_extension_flexion' : {
+        'joint_center': 'left_knee',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'left_hip',
+            'reference_vector_end': 'left_knee',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_knee',
+            'rotation_vector_end': 'left_ankle',
+        },
+    },
+    'left_hip_extension_flexion' : {
+        'joint_center': 'left_hip',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'trunk_center',
+            'reference_vector_end': 'hips_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_hip',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'left_hip',
+                'projected_vector_end': 'left_knee',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'trunk_center',
+                        'plane_axis_1_end': 'hips_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'crossproduct',
+                        'plane_axis_2_cross_1_origin': 'trunk_center',
+                        'plane_axis_2_cross_1_end': 'hips_center',
+                        'plane_axis_2_cross_2_origin': 'hips_center',
+                        'plane_axis_2_cross_2_end': 'left_hip',
+                    },
+                }
+            }
+        },
+    },
+    'left_hip_abduction_adduction': {
+        'joint_center': 'left_hip',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'trunk_center',
+            'reference_vector_end': 'hips_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_hip',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'left_hip',
+                'projected_vector_end': 'left_knee',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'trunk_center',
+                        'plane_axis_1_end': 'hips_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'hips_center',
+                        'plane_axis_2_end': 'left_hip',
+                    },
+                }
+            }
+        },
+    },
+    # 'left_hip_rotation': {
+    #     'joint_center': 'left_hip',
+    #     'reference_vector': {
+    #         'type': 'crossproduct',
+    #         'reference_cross_1_origin': 'left_hip',
+    #         'reference_cross_1_end': 'left_knee',
+    #         'reference_cross_2_origin': 'hips_center',
+    #         'reference_cross_2_end': 'left_hip',
+    #     },
+    #     'rotation_vector': {
+    #         'rotation_vector_origin': 'left_hip',
+    #         'rotation_vector_end': {
+                  ## TODO: Improve the projection logic so it can work
+                  ##       with a projected vector that it doesn't have
+                  ##       the same origin as the rotion vector. Like
+                  ##       the ankle-foot_index vector in this case
+    #             'projected_vector_origin': 'left_hip',
+    #             'projected_vector_end': 'left_foot_index',
+    #             'projection_plane': {
+    #                 'plane_axis_1': {
+    #                     'type': 'vector',
+    #                     'plane_axis_1_origin': 'hips_center',
+    #                     'plane_axis_1_end': 'left_hip',
+    #                 },
+    #                 'plane_axis_2': {
+    #                     'type': 'crossproduct',
+    #                     'plane_axis_2_cross_1_origin': 'left_hip',
+    #                     'plane_axis_2_cross_1_end': 'left_knee',
+    #                     'plane_axis_2_cross_2_origin': 'hips_center',
+    #                     'plane_axis_2_cross_2_end': 'left_hip',
+    #                 },
+    #             }
+    #         }
+    #     },
+    # },
+    'right_knee_extension_flexion' : {
+        'joint_center': 'right_knee',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'right_hip',
+            'reference_vector_end': 'right_knee',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_knee',
+            'rotation_vector_end': 'right_ankle',
+        },
+    },
+    'right_hip_extension_flexion' : {
+        'joint_center': 'right_hip',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'trunk_center',
+            'reference_vector_end': 'hips_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_hip',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'right_hip',
+                'projected_vector_end': 'right_knee',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'trunk_center',
+                        'plane_axis_1_end': 'hips_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'crossproduct',
+                        'plane_axis_2_cross_1_origin': 'hips_center',
+                        'plane_axis_2_cross_1_end': 'right_hip',
+                        'plane_axis_2_cross_2_origin': 'trunk_center',
+                        'plane_axis_2_cross_2_end': 'hips_center',
+                    },
+                }
+            }
+        },
+    },
+    'right_hip_abduction_adduction': {
+        'joint_center': 'right_hip',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'trunk_center',
+            'reference_vector_end': 'hips_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_hip',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'right_hip',
+                'projected_vector_end': 'right_knee',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'trunk_center',
+                        'plane_axis_1_end': 'hips_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'hips_center',
+                        'plane_axis_2_end': 'right_hip',
+                    },
+                }
+            }
+        },
+    },
+    'neck_extension_flexion' : {
+        'joint_center': 'neck_center',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'trunk_center',
+            'reference_vector_end': 'neck_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'neck_center',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'neck_center',
+                'projected_vector_end': 'head_center',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'trunk_center',
+                        'plane_axis_1_end': 'neck_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'crossproduct',
+                        'plane_axis_2_cross_1_origin': 'trunk_center',
+                        'plane_axis_2_cross_1_end': 'neck_center',
+                        'plane_axis_2_cross_2_origin': 'neck_center',
+                        'plane_axis_2_cross_2_end': 'right_shoulder',
+                    },
+                }
+            }
+        },
+    },
+    'neck_lateral_flexion': {
+        'joint_center': 'neck_center',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'trunk_center',
+            'reference_vector_end': 'neck_center',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'neck_center',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'neck_center',
+                'projected_vector_end': 'head_center',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'trunk_center',
+                        'plane_axis_1_end': 'neck_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'neck_center',
+                        'plane_axis_2_end': 'left_shoulder',
+                    },
+                }
+            }
+        },
+    },
+    'neck_rotation': {
+        'joint_center': 'neck_center',
+        'reference_vector': {
+            'type': 'crossproduct',
+            'reference_cross_1_origin': 'neck_center',
+            'reference_cross_1_end': 'head_center',
+            'reference_cross_2_origin': 'neck_center',
+            'reference_cross_2_end': 'right_shoulder',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'neck_center',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'neck_center',
+                'projected_vector_end': 'nose',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'doublecrossproduct',
+                        'plane_axis_1_cross_1_origin': 'neck_center',
+                        'plane_axis_1_cross_1_end': 'head_center',
+                        'plane_axis_1_cross_2_origin': 'neck_center',
+                        'plane_axis_1_cross_2_end': 'right_shoulder',
+                        'plane_axis_1_cross_3_origin': 'neck_center',
+                        'plane_axis_1_cross_3_end': 'head_center',
+                    },
+                    'plane_axis_2': {
+                        'type': 'crossproduct',
+                        'plane_axis_2_cross_1_origin': 'neck_center',
+                        'plane_axis_2_cross_1_end': 'right_shoulder',
+                        'plane_axis_2_cross_2_origin': 'neck_center',
+                        'plane_axis_2_cross_2_end': 'head_center',
+                    },
+                }
+            }
+        },
+    },
+    # TODO: Define a better reference vector and rotation plane because
+    # when the leg is fully extended the thigh and shin bones might form
+    # unwanted angles. The most obvious choice is to just use knee-ankle
+    # and ankle-foot_index, but that ommits the other ankle rotations
+    # TODO: Add an offset to the angle so it is 0º when it is on the a 
+    # standing straight pose
+    'left_ankle_dorsiflexion_plantarflexion' : {
+        'joint_center': 'left_ankle',
+        'reference_vector': {
+            'type': 'doublecrossproduct',
+                'reference_cross_1_origin': 'left_knee',
+                'reference_cross_1_end': 'left_ankle',
+                'reference_cross_2_origin': 'left_ankle',
+                'reference_cross_2_end': 'left_foot_index',
+                'reference_cross_3_origin': 'left_knee',
+                'reference_cross_3_end': 'left_ankle',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_ankle',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'left_ankle',
+                'projected_vector_end': 'left_foot_index',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'left_knee',
+                        'plane_axis_1_end': 'left_ankle',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'left_knee',
+                        'plane_axis_2_end': 'left_foot_index',
+                    },
+                }
+            }
+        },
+    },
+    'left_ankle_inversion_eversion' : {
+        'joint_center': 'left_ankle',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'left_knee',
+            'reference_vector_end': 'left_ankle',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_ankle',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'left_ankle',
+                'projected_vector_end': 'left_heel',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'crossproduct',
+                        'plane_axis_1_cross_1_origin': 'left_hip',
+                        'plane_axis_1_cross_1_end': 'left_knee',
+                        'plane_axis_1_cross_2_origin': 'left_knee',
+                        'plane_axis_1_cross_2_end': 'left_ankle',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'left_knee',
+                        'plane_axis_2_end': 'left_ankle',
+                    },
+                }
+            }
+        },
+    },
+    'right_ankle_dorsiflexion_plantarflexion' : {
+        'joint_center': 'right_ankle',
+        'reference_vector': {
+            'type': 'doublecrossproduct',
+                'reference_cross_1_origin': 'right_knee',
+                'reference_cross_1_end': 'right_ankle',
+                'reference_cross_2_origin': 'right_ankle',
+                'reference_cross_2_end': 'right_foot_index',
+                'reference_cross_3_origin': 'right_knee',
+                'reference_cross_3_end': 'right_ankle',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_ankle',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'right_ankle',
+                'projected_vector_end': 'right_foot_index',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'right_knee',
+                        'plane_axis_1_end': 'right_ankle',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'right_knee',
+                        'plane_axis_2_end': 'right_foot_index',
+                    },
+                }
+            }
+        },
+    },
+    'right_ankle_inversion_eversion' : {
+        'joint_center': 'right_ankle',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'right_knee',
+            'reference_vector_end': 'right_ankle',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_ankle',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'right_ankle',
+                'projected_vector_end': 'right_heel',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'right_knee',
+                        'plane_axis_1_end': 'right_ankle',
+                    },
+                    'plane_axis_2': {
+                        'type': 'crossproduct',
+                        'plane_axis_2_cross_1_origin': 'right_hip',
+                        'plane_axis_2_cross_1_end': 'right_knee',
+                        'plane_axis_2_cross_2_origin': 'right_knee',
+                        'plane_axis_2_cross_2_end': 'right_ankle',
+                    },
+                }
+            }
+        },
+    },
+    # TODO: Find a better way to define the reference vector. As the pelvis
+    # is only defined by two markers, it can be determined what is its
+    # rotation in the Sagittal plane. The approach to use the average of the 
+    # two thighs is an approximation when both legs are rotated equally
+    # like when standing still.
+    'spine_extension_flexion' : {
+        'joint_center': 'hips_center',
+        'reference_vector': {
+            'type': 'average',
+            'reference_average_1_origin': 'left_knee',
+            'reference_average_1_end': 'left_hip',
+            'reference_average_2_origin': 'right_knee',
+            'reference_average_2_end': 'right_hip',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'hips_center',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'hips_center',
+                'projected_vector_end': 'trunk_center',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'average',
+                        'plane_axis_1_average_1_origin': 'left_knee',
+                        'plane_axis_1_average_1_end': 'left_hip',
+                        'plane_axis_1_average_2_origin': 'right_knee',
+                        'plane_axis_1_average_2_end': 'right_hip',
+                    },
+                    'plane_axis_2': {
+                        'type': 'average_crossproduct',
+                        'plane_axis_2_average_1_origin': 'left_knee',
+                        'plane_axis_2_average_1_end': 'left_hip',
+                        'plane_axis_2_average_2_origin': 'right_knee',
+                        'plane_axis_2_average_2_end': 'right_hip',
+                        'plane_axis_2_cross_1_origin': 'hips_center',
+                        'plane_axis_2_cross_1_end': 'right_hip',                        
+                    },
+                }
+            }
+        },
+    },
+    # TODO: Same thing as spine flexion extension reference vector
+    'spine_lateral_flexion' : {
+        'joint_center': 'hips_center',
+        'reference_vector': {
+            'type': 'average',
+            'reference_average_1_origin': 'left_knee',
+            'reference_average_1_end': 'left_hip',
+            'reference_average_2_origin': 'right_knee',
+            'reference_average_2_end': 'right_hip',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'hips_center',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'hips_center',
+                'projected_vector_end': 'trunk_center',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'hips_center',
+                        'plane_axis_1_end': 'left_hip',   
+                    },
+                    'plane_axis_2': {
+                        'type': 'average',
+                        'plane_axis_2_average_1_origin': 'left_knee',
+                        'plane_axis_2_average_1_end': 'left_hip',
+                        'plane_axis_2_average_2_origin': 'right_knee',
+                        'plane_axis_2_average_2_end': 'right_hip',
+                    },
+                }
+            }
+        },
+    },
+    # TODO: Check the constraints of the hand. Mediapipe body hand markers
+    # and hand markers are not aligned. Probably placed them at average position?
+    'left_hand_extension_flexion' : {
+        'joint_center': 'left_wrist',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'left_elbow',
+            'reference_vector_end': 'left_wrist',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'left_wrist',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'left_wrist',
+                'projected_vector_end': 'left_hand_middle',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'vector',
+                        'plane_axis_1_origin': 'left_elbow',
+                        'plane_axis_1_end': 'left_wrist',   
+                    },
+                    'plane_axis_2': {
+                        'type': 'crossproduct',
+                        'plane_axis_2_cross_1_origin': 'left_elbow',
+                        'plane_axis_2_cross_1_end': 'left_wrist',
+                        'plane_axis_2_cross_2_origin': 'left_wrist',
+                        'plane_axis_2_cross_2_end': 'left_hand_thumb_cmc',
+                    },
+                }
+            }
+        },
+    },
+    'right_hand_extension_flexion' : {
+        'joint_center': 'right_wrist',
+        'reference_vector': {
+            'type': 'vector',
+            'reference_vector_origin': 'right_elbow',
+            'reference_vector_end': 'right_wrist',
+        },
+        'rotation_vector': {
+            'rotation_vector_origin': 'right_wrist',
+            'rotation_vector_end': {
+                'projected_vector_origin': 'right_wrist',
+                'projected_vector_end': 'right_hand_middle',
+                'projection_plane': {
+                    'plane_axis_1': {
+                        'type': 'crossproduct',
+                        'plane_axis_1_cross_1_origin': 'right_elbow',
+                        'plane_axis_1_cross_1_end': 'right_wrist',
+                        'plane_axis_1_cross_2_origin': 'right_wrist',
+                        'plane_axis_1_cross_2_end': 'right_hand_thumb_cmc',
+                    },
+                    'plane_axis_2': {
+                        'type': 'vector',
+                        'plane_axis_2_origin': 'right_elbow',
+                        'plane_axis_2_end': 'right_wrist',
+                    },
+                }
+            }
+        },
+    },
+}

--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -12,6 +12,8 @@ from ajc27_freemocap_blender_addon.freemocap_data_handler.utilities.load_data im
 from .create_rig.add_rig_method_enum import AddRigMethods
 from .create_rig.create_rig import create_rig
 
+from .calculate_joint_angles.calculate_joint_angles import calculate_joint_angles
+
 from .create_video.create_video import create_video
 from .export_3d_model.export_3d_model import export_3d_model
 from .empties.creation.create_freemocap_empties import create_freemocap_empties
@@ -177,6 +179,34 @@ class MainController:
             )
         except Exception as e:
             print(f"Failed during `fix hand data`, error: `{e}`")
+            print(e)
+            raise e
+        
+    def calculate_joint_angles(self):
+        try:
+            print("Calculating joint angles...")
+            # Get the combined marker names
+            marker_names = (
+                list(self.freemocap_data_handler.body_names) + 
+                list(self.freemocap_data_handler.right_hand_names) + 
+                list(self.freemocap_data_handler.left_hand_names)
+            )
+            marker_frame_xyz = np.concatenate(
+                [
+                    self.freemocap_data_handler.body_frame_name_xyz,
+                    self.freemocap_data_handler.right_hand_frame_name_xyz,
+                    self.freemocap_data_handler.left_hand_frame_name_xyz,
+                ],
+                axis=1,
+            )
+            calculate_joint_angles(
+                output_path=str(Path(self.recording_path) / "output_data" / "joint_angles.csv"),
+                marker_names=marker_names,
+                marker_frame_xyz=marker_frame_xyz
+            )
+            self.freemocap_data_handler.mark_processing_stage("calculate_joint_angles")
+        except Exception as e:
+            print(f"Failed to calculate joint angles: {e}")
             print(e)
             raise e
 
@@ -411,6 +441,11 @@ class MainController:
         self.fix_hand_data()
         end_time = time.perf_counter_ns()
         stage_times['fix_hand_data'] = (end_time - start_time)/1e9
+
+        start_time = time.perf_counter_ns()
+        self.calculate_joint_angles()
+        end_time = time.perf_counter_ns()
+        stage_times['calculate_joint_angles'] = (end_time - start_time)/1e9
 
         start_time = time.perf_counter_ns()
         self.save_data_to_disk()

--- a/ajc27_freemocap_blender_addon/core_functions/main_controller.py
+++ b/ajc27_freemocap_blender_addon/core_functions/main_controller.py
@@ -13,6 +13,7 @@ from .create_rig.add_rig_method_enum import AddRigMethods
 from .create_rig.create_rig import create_rig
 
 from .calculate_joint_angles.calculate_joint_angles import calculate_joint_angles
+from .calculate_joint_angles.joint_angle_definitions import joint_angles_definitions
 
 from .create_video.create_video import create_video
 from .export_3d_model.export_3d_model import export_3d_model
@@ -202,7 +203,8 @@ class MainController:
             calculate_joint_angles(
                 output_path=str(Path(self.recording_path) / "output_data" / "joint_angles.csv"),
                 marker_names=marker_names,
-                marker_frame_xyz=marker_frame_xyz
+                marker_frame_xyz=marker_frame_xyz,
+                joint_angles_definitions=joint_angles_definitions,
             )
             self.freemocap_data_handler.mark_processing_stage("calculate_joint_angles")
         except Exception as e:


### PR DESCRIPTION
@jonmatthis @aaroncherian Here is the calculate joint angles function. I refactored the previous function from the UI using dataclasses. The algorithm is the same. I just added an offset variable for those angles that have a special rest position (zero degree angle) like the ankle.

The function runs directly with the main exporting function generating a csv and a npy file in the output_data folder. 