### PR TITLE
Improved limit markers range of motion

### DIFF
--- a/ajc27_freemocap_blender_addon/blender_ui/operators/animation/limit_markers_range_of_motion/_limit_markers_range_of_motion.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/operators/animation/limit_markers_range_of_motion/_limit_markers_range_of_motion.py
@@ -4,10 +4,11 @@ import math as m
 from mathutils import Vector, Matrix
 from copy import deepcopy
 from dataclasses import make_dataclass, field
+import re
 
 from ajc27_freemocap_blender_addon.data_models.bones.bone_definitions import _BONE_DEFINITIONS
 from ajc27_freemocap_blender_addon.data_models.mediapipe_names.mediapipe_heirarchy import get_mediapipe_hierarchy
-
+from ajc27_freemocap_blender_addon.blender_ui.ui_utilities.ui_utilities import draw_vector
 
 
 class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
@@ -42,6 +43,7 @@ class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
         
         range_of_motion_scale = props.range_of_motion_scale
         hand_locked_track_marker_name = props.hand_locked_track_marker
+        hand_damped_track_marker_name = props.hand_damped_track_marker
 
         BONE_DEFINITIONS = deepcopy(_BONE_DEFINITIONS)
         
@@ -104,6 +106,16 @@ class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
             bone.head = next((k for k in markers.keys() if k.startswith(bone.head)), None)
             # Set bone.tail as the best match of bone.tail in markers.keys()
             bone.tail = next((k for k in markers.keys() if k.startswith(bone.tail)), None)
+
+        # Change the hand bone tail marker with the one in hand_damped_track_marker
+        # Consider the current markers in the markers dictionary (strip possible .000 number at the end to compare)
+        for side in ['left', 'right']:
+            side_initial = side[0].upper()
+            target_marker = f"{side}_{hand_damped_track_marker_name}"
+            VirtualBones[f'hand.{side_initial}'].tail = next(
+                (k for k in markers.keys() if re.sub(r'\.\d{3}$', '', k) == target_marker),
+                None
+            )
 
         # Modify the keys and the children values in MEDIAPIPE_HIERARCHY
         # so they match the markers that are children of the data parent empty
@@ -172,11 +184,38 @@ class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
                 # If the bone has the hands or fingers category then calculate its origin axes based on its parent bone's axes
                 if VirtualBones[bone].category in ['palm', 'proximal_phalanx', 'intermediate_phalanx', 'distal_phalanx']:
 
+                    bone_head_position = Vector(markers[VirtualBones[bone].head]['fcurves'][:, frame])
+                    bone_tail_position = Vector(markers[VirtualBones[bone].tail]['fcurves'][:, frame])
+
+                    # If the bone is an index, ring or pinky metacarpal then adjust its head marker position
+                    if bone in {'palm.01.L', 'palm.01.R', 'palm.03.L', 'palm.03.R', 'palm.04.L', 'palm.04.R'}:
+                    # if bone in {'palm.01.R', 'palm.03.R', 'palm.04.R'} and frame == 316:
+                        bone_head_position = compute_new_metacarpal_head(
+                            metacarpal_head=bone_head_position,
+                            metacarpal_tail=bone_tail_position,
+                            reference_head=Vector(markers[VirtualBones[VirtualBones[bone].parent_bone].head]['fcurves'][:, frame]),
+                            reference_tail=Vector(markers[VirtualBones[VirtualBones[bone].parent_bone].tail]['fcurves'][:, frame]),
+                            new_head_metacarpal_ratio=VirtualBones[bone].new_head_metacarpal_ratio,
+                            angle_offset=VirtualBones[bone].angle_offset,
+                        )
+
+                        # # Add an empty marker at the new head position for debugging
+                        if frame == 316:
+                            bpy.ops.object.empty_add(type='PLAIN_AXES', location=bone_head_position)
+                            empty = bpy.context.active_object
+                            empty.name = f"Debug New Head {bone} Frame {frame}"
+                    
                     # Calculate the bone's y axis
                     bone_y_axis = (
-                        Vector(markers[VirtualBones[bone].tail]['fcurves'][:, frame])
-                        - Vector(markers[VirtualBones[bone].head]['fcurves'][:, frame])
+                        bone_tail_position
+                        - bone_head_position
                     )
+
+                    # # Calculate the bone's y axis
+                    # bone_y_axis = (
+                    #     Vector(markers[VirtualBones[bone].tail]['fcurves'][:, frame])
+                    #     - Vector(markers[VirtualBones[bone].head]['fcurves'][:, frame])
+                    # )
 
                     # Get the bone axes from its parent
                     bone_axes_from_parent = calculate_bone_axes_from_parent(
@@ -188,6 +227,35 @@ class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
                         ],
                     )
 
+                    if bone in {'palm.01.L'} and frame == 316:
+                        # Debugging
+                        draw_vector(
+                            bone_head_position,
+                            VirtualBones[bone].bone_y_axis,
+                            'Palm 01 L Y Axis from parent',
+                            )
+                        draw_vector(
+                            bone_head_position,
+                            VirtualBones[bone].bone_z_axis,
+                            'Palm 01 L Z Axis from parent',
+                            )
+                        
+                    if bone in {'f_index.01.L'} and frame == 316:
+                        # Debugging
+                        draw_vector(
+                            markers[VirtualBones[bone].head]['fcurves'][:, frame],
+                            bone_axes_from_parent[2],
+                            'Index 01 L Z Axis from parent',
+                            )
+                        
+                    if bone in {'f_index.02.L'} and frame == 316:
+                        # Debugging
+                        draw_vector(
+                            markers[VirtualBones[bone].head]['fcurves'][:, frame],
+                            bone_axes_from_parent[2],
+                            'Index 02 L Z Axis from parent',
+                            )
+
                     # Save the vectors in the virtual_bones dictionary
                     VirtualBones[bone].bone_x_axis = bone_axes_from_parent[0]
                     VirtualBones[bone].bone_y_axis = bone_axes_from_parent[1]
@@ -197,6 +265,13 @@ class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
                     # origin axes based on its parent bone's axes and rotate
                     # the tail empty (and its children) to meet the constraints
                     if VirtualBones[bone].category in target_categories:
+                        if bone == 'f_index.02.L' and frame == 316:
+                            # Debugging
+                            draw_vector(
+                                markers[VirtualBones['f_index.01.L'].head]['fcurves'][:, frame],
+                                VirtualBones[bone].bone_z_axis,
+                                'Index 02 Z Axis',
+                                )
                         for axis in ['x', 'z']:
                             # Get the min and max rotation limits based on the range of motion scale
                             axis_rotation_limit_min = getattr(VirtualBones[bone], f'{axis}_rotation_limit_min')
@@ -371,3 +446,31 @@ def rotate_marker_around_pivot(
             )
 
     return
+
+# Function to get the correct head position of the metacarpals
+def compute_new_metacarpal_head(
+    metacarpal_head: Vector,
+    metacarpal_tail: Vector,
+    reference_head: Vector,
+    reference_tail: Vector,
+    new_head_metacarpal_ratio: float,
+    angle_offset: float
+) -> Vector:
+
+    # Current and reference vectors
+    current_metacarpal_vector = (metacarpal_tail - metacarpal_head).normalized()
+    reference_vector = (reference_tail - reference_head).normalized()
+
+    # Plane normal between them
+    rotation_plane_normal = reference_vector.cross(current_metacarpal_vector).normalized()
+
+    # Vector scaled by ratio
+    rotating_vector = (metacarpal_tail - metacarpal_head) * new_head_metacarpal_ratio
+
+    # Rotate by angle_offset around the plane normal
+    angle_offset_rad = m.radians(angle_offset)
+    rotation_matrix = Matrix.Rotation(angle_offset_rad, 4, rotation_plane_normal)
+    rotated_vector = rotation_matrix @ rotating_vector
+
+    # New head position
+    return metacarpal_head + rotated_vector

--- a/ajc27_freemocap_blender_addon/blender_ui/operators/animation/limit_markers_range_of_motion/_limit_markers_range_of_motion.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/operators/animation/limit_markers_range_of_motion/_limit_markers_range_of_motion.py
@@ -8,7 +8,6 @@ import re
 
 from ajc27_freemocap_blender_addon.data_models.bones.bone_definitions import _BONE_DEFINITIONS
 from ajc27_freemocap_blender_addon.data_models.mediapipe_names.mediapipe_heirarchy import get_mediapipe_hierarchy
-from ajc27_freemocap_blender_addon.blender_ui.ui_utilities.ui_utilities import draw_vector
 
 
 class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
@@ -199,23 +198,11 @@ class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
                             angle_offset=VirtualBones[bone].angle_offset,
                         )
 
-                        # # Add an empty marker at the new head position for debugging
-                        if frame == 316:
-                            bpy.ops.object.empty_add(type='PLAIN_AXES', location=bone_head_position)
-                            empty = bpy.context.active_object
-                            empty.name = f"Debug New Head {bone} Frame {frame}"
-                    
                     # Calculate the bone's y axis
                     bone_y_axis = (
                         bone_tail_position
                         - bone_head_position
                     )
-
-                    # # Calculate the bone's y axis
-                    # bone_y_axis = (
-                    #     Vector(markers[VirtualBones[bone].tail]['fcurves'][:, frame])
-                    #     - Vector(markers[VirtualBones[bone].head]['fcurves'][:, frame])
-                    # )
 
                     # Get the bone axes from its parent
                     bone_axes_from_parent = calculate_bone_axes_from_parent(
@@ -227,35 +214,6 @@ class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
                         ],
                     )
 
-                    if bone in {'palm.01.L'} and frame == 316:
-                        # Debugging
-                        draw_vector(
-                            bone_head_position,
-                            VirtualBones[bone].bone_y_axis,
-                            'Palm 01 L Y Axis from parent',
-                            )
-                        draw_vector(
-                            bone_head_position,
-                            VirtualBones[bone].bone_z_axis,
-                            'Palm 01 L Z Axis from parent',
-                            )
-                        
-                    if bone in {'f_index.01.L'} and frame == 316:
-                        # Debugging
-                        draw_vector(
-                            markers[VirtualBones[bone].head]['fcurves'][:, frame],
-                            bone_axes_from_parent[2],
-                            'Index 01 L Z Axis from parent',
-                            )
-                        
-                    if bone in {'f_index.02.L'} and frame == 316:
-                        # Debugging
-                        draw_vector(
-                            markers[VirtualBones[bone].head]['fcurves'][:, frame],
-                            bone_axes_from_parent[2],
-                            'Index 02 L Z Axis from parent',
-                            )
-
                     # Save the vectors in the virtual_bones dictionary
                     VirtualBones[bone].bone_x_axis = bone_axes_from_parent[0]
                     VirtualBones[bone].bone_y_axis = bone_axes_from_parent[1]
@@ -265,13 +223,6 @@ class FREEMOCAP_OT_limit_markers_range_of_motion(bpy.types.Operator):
                     # origin axes based on its parent bone's axes and rotate
                     # the tail empty (and its children) to meet the constraints
                     if VirtualBones[bone].category in target_categories:
-                        if bone == 'f_index.02.L' and frame == 316:
-                            # Debugging
-                            draw_vector(
-                                markers[VirtualBones['f_index.01.L'].head]['fcurves'][:, frame],
-                                VirtualBones[bone].bone_z_axis,
-                                'Index 02 Z Axis',
-                                )
                         for axis in ['x', 'z']:
                             # Get the min and max rotation limits based on the range of motion scale
                             axis_rotation_limit_min = getattr(VirtualBones[bone], f'{axis}_rotation_limit_min')

--- a/ajc27_freemocap_blender_addon/blender_ui/properties/subclasses/limit_markers_range_of_motion_properties.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/properties/subclasses/limit_markers_range_of_motion_properties.py
@@ -52,7 +52,22 @@ class LimitMarkersRangeOfMotionProperties(bpy.types.PropertyGroup):
             + ' Useful when calculating the initial hand axes.'
         ),
         items = [
+            ('hand_index_finger_mcp', 'hand_index_finger_mcp', ''),
             ('index', 'index', ''),
-            ('hand_thumb_cmc', 'hand_thumb_cmc', ''),
+            ('hand_thumb_cmc', 'hand_thumb_cmc', ''),            
         ]
     )  # type: ignore
+
+    hand_damped_track_marker: PropertyTypes.Enum(
+        name='',
+        description=(
+            'Hand damped track marker where the y axis points to.'
+            + ' Useful when calculating the initial hand axes.'
+        ),
+        items = [
+            ('hand_middle_finger_mcp', 'hand_middle_finger_mcp', ''),
+            ('hand_middle', 'hand_middle', ''),            
+        ]
+    )  # type: ignore
+
+

--- a/ajc27_freemocap_blender_addon/blender_ui/sub_panels/animation_panel.py
+++ b/ajc27_freemocap_blender_addon/blender_ui/sub_panels/animation_panel.py
@@ -111,29 +111,33 @@ class VIEW3D_PT_animation_panel(bpy.types.Panel):
         if limit_markers_range_of_motion_props.show_limit_markers_range_of_motion_options:
             box = layout.box()
 
-            split = box.column().row().split(factor=0.8)
+            split = box.column().row().split(factor=0.7)
             split.column().label(text='Limit Palm Markers')
             split.column().prop(limit_markers_range_of_motion_props, 'limit_palm_markers')
 
-            split = box.column().row().split(factor=0.8)
+            split = box.column().row().split(factor=0.7)
             split.column().label(text='Limit Proximal Phalanx Markers')
             split.column().prop(limit_markers_range_of_motion_props, 'limit_proximal_phalanx_markers')
 
-            split = box.column().row().split(factor=0.8)
+            split = box.column().row().split(factor=0.7)
             split.column().label(text='Limit Intermediate Phalanx Markers')
             split.column().prop(limit_markers_range_of_motion_props, 'limit_intermediate_phalanx_markers')
 
-            split = box.column().row().split(factor=0.8)
+            split = box.column().row().split(factor=0.7)
             split.column().label(text='Limit Distal Phalanx Markers')
             split.column().prop(limit_markers_range_of_motion_props, 'limit_distal_phalanx_markers')
 
-            split = box.column().row().split(factor=0.8)
+            split = box.column().row().split(factor=0.7)
             split.column().label(text='Range of Motion Scale')
             split.column().prop(limit_markers_range_of_motion_props, 'range_of_motion_scale')
 
-            split = box.column().row().split(factor=0.8)
+            split = box.column().row().split(factor=0.7)
             split.column().label(text='Hand Locked Track Marker')
             split.column().prop(limit_markers_range_of_motion_props, 'hand_locked_track_marker')
+
+            split = box.column().row().split(factor=0.7)
+            split.column().label(text='Hand Damped Track Marker')
+            split.column().prop(limit_markers_range_of_motion_props, 'hand_damped_track_marker')
 
             # TODO: Add fields to adjust the min max axis limit values
             # Not sure what to use, degrees amount, a percentage of the min-max range?

--- a/ajc27_freemocap_blender_addon/data_models/bones/bone_definitions.py
+++ b/ajc27_freemocap_blender_addon/data_models/bones/bone_definitions.py
@@ -16,6 +16,8 @@ class BoneDefinition:
     x_rotation_limit_max: float = 0.0
     z_rotation_limit_min: float = 0.0
     z_rotation_limit_max: float = 0.0
+    new_head_metacarpal_ratio: float = 0.0,
+    angle_offset: float = 0.0
 
 # TODO: Adjust the x and z rotation limits for hand bones to make the
 # Range of motion limit less stiff
@@ -137,10 +139,10 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         tail='right_hand_thumb_ip',
         category='proximal_phalanx',
         parent_bone='thumb.01.R',
-        x_rotation_limit_min=0,
+        x_rotation_limit_min=-20,
         x_rotation_limit_max=40,
-        z_rotation_limit_min=-10,
-        z_rotation_limit_max=10,
+        z_rotation_limit_min=-50,
+        z_rotation_limit_max=50,
     ),
     'thumb.02.L': BoneDefinition(
         head='left_hand_thumb_mcp',
@@ -148,9 +150,9 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         category='proximal_phalanx',
         parent_bone='thumb.01.L',
         x_rotation_limit_min=-40,
-        x_rotation_limit_max=0,
-        z_rotation_limit_min=-10,
-        z_rotation_limit_max=10,
+        x_rotation_limit_max=20,
+        z_rotation_limit_min=-50,
+        z_rotation_limit_max=50,
     ),
     'thumb.03.R': BoneDefinition(
         head='right_hand_thumb_ip',
@@ -159,8 +161,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='thumb.02.R',
         x_rotation_limit_min=-10,
         x_rotation_limit_max=90,
-        z_rotation_limit_min=0,
-        z_rotation_limit_max=0,
+        z_rotation_limit_min=-10,
+        z_rotation_limit_max=10,
     ),
     'thumb.03.L': BoneDefinition(
         head='left_hand_thumb_ip',
@@ -169,8 +171,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='thumb.02.L',
         x_rotation_limit_min=-90,
         x_rotation_limit_max=10,
-        z_rotation_limit_min=0,
-        z_rotation_limit_max=0,
+        z_rotation_limit_min=-10,
+        z_rotation_limit_max=10,
     ),
     'palm.01.R': BoneDefinition(
         head='right_hand_wrist',
@@ -179,8 +181,10 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='hand.R',
         x_rotation_limit_min=-180,
         x_rotation_limit_max=180,
-        z_rotation_limit_min=14,
-        z_rotation_limit_max=16,
+        z_rotation_limit_min=12,
+        z_rotation_limit_max=18,
+        new_head_metacarpal_ratio=0.22,
+        angle_offset=15.0,
     ),
     'palm.01.L': BoneDefinition(
         head='left_hand_wrist',
@@ -189,8 +193,10 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='hand.L',
         x_rotation_limit_min=-180,
         x_rotation_limit_max=180,
-        z_rotation_limit_min=14,
-        z_rotation_limit_max=16,
+        z_rotation_limit_min=12,
+        z_rotation_limit_max=18,
+        new_head_metacarpal_ratio=0.22,
+        angle_offset=15.0,
     ),
     'f_index.01.R': BoneDefinition(
         head='right_hand_index_finger_mcp',
@@ -219,8 +225,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='f_index.01.R',
         x_rotation_limit_min=0,
         x_rotation_limit_max=90,
-        z_rotation_limit_min=-1, # Setting 1 degree to have a minimum range to scale
-        z_rotation_limit_max=1,
+        z_rotation_limit_min=-2, # Setting a few degrees to have a minimum range to scale
+        z_rotation_limit_max=2,
     ),
     'f_index.02.L': BoneDefinition(
         head='left_hand_index_finger_pip',
@@ -229,8 +235,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='f_index.01.L',
         x_rotation_limit_min=-90,
         x_rotation_limit_max=0,
-        z_rotation_limit_min=-1,
-        z_rotation_limit_max=1,
+        z_rotation_limit_min=-2,
+        z_rotation_limit_max=2,
     ),
     'f_index.03.R': BoneDefinition(
         head='right_hand_index_finger_dip',
@@ -259,8 +265,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='hand.R',
         x_rotation_limit_min=-180,
         x_rotation_limit_max=180,
-        z_rotation_limit_min=0,
-        z_rotation_limit_max=0,
+        z_rotation_limit_min=-1,
+        z_rotation_limit_max=1,
     ),
     'palm.02.L': BoneDefinition(
         head='left_hand_wrist',
@@ -269,8 +275,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='hand.L',
         x_rotation_limit_min=-20,
         x_rotation_limit_max=20,
-        z_rotation_limit_min=0,
-        z_rotation_limit_max=0,
+        z_rotation_limit_min=-1,
+        z_rotation_limit_max=1,
     ),
     'f_middle.01.R': BoneDefinition(
         head='right_hand_middle_finger_mcp',
@@ -299,8 +305,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='f_middle.01.R',
         x_rotation_limit_min=0,
         x_rotation_limit_max=90,
-        z_rotation_limit_min=-1,
-        z_rotation_limit_max=1,
+        z_rotation_limit_min=-2,
+        z_rotation_limit_max=2,
     ),
     'f_middle.02.L': BoneDefinition(
         head='left_hand_middle_finger_pip',
@@ -309,8 +315,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='f_middle.01.L',
         x_rotation_limit_min=-90,
         x_rotation_limit_max=0,
-        z_rotation_limit_min=-1,
-        z_rotation_limit_max=1,
+        z_rotation_limit_min=-2,
+        z_rotation_limit_max=2,
     ),
     'f_middle.03.R': BoneDefinition(
         head='right_hand_middle_finger_dip',
@@ -339,8 +345,10 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='hand.R',
         x_rotation_limit_min=-180,
         x_rotation_limit_max=180,
-        z_rotation_limit_min=-16,
-        z_rotation_limit_max=-14,
+        z_rotation_limit_min=-18,
+        z_rotation_limit_max=-12,
+        new_head_metacarpal_ratio=0.24,
+        angle_offset=15.0,
     ),
     'palm.03.L': BoneDefinition(
         head='left_hand_wrist',
@@ -349,8 +357,10 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='hand.L',
         x_rotation_limit_min=-180,
         x_rotation_limit_max=180,
-        z_rotation_limit_min=-16,
-        z_rotation_limit_max=-14,
+        z_rotation_limit_min=-18,
+        z_rotation_limit_max=-12,
+        new_head_metacarpal_ratio=0.24,
+        angle_offset=15.0,
     ),
     'f_ring.01.R': BoneDefinition(
         head='right_hand_ring_finger_mcp',
@@ -379,8 +389,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='f_ring.01.R',
         x_rotation_limit_min=0,
         x_rotation_limit_max=90,
-        z_rotation_limit_min=-1,
-        z_rotation_limit_max=1,
+        z_rotation_limit_min=-2,
+        z_rotation_limit_max=2,
     ),
     'f_ring.02.L': BoneDefinition(
         head='left_hand_ring_finger_pip',
@@ -389,8 +399,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='f_ring.01.L',
         x_rotation_limit_min=-90,
         x_rotation_limit_max=0,
-        z_rotation_limit_min=-1,
-        z_rotation_limit_max=1,
+        z_rotation_limit_min=-2,
+        z_rotation_limit_max=2,
     ),
     'f_ring.03.R': BoneDefinition(
         head='right_hand_ring_finger_dip',
@@ -419,8 +429,10 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='hand.R',
         x_rotation_limit_min=-180,
         x_rotation_limit_max=180,
-        z_rotation_limit_min=-31,
-        z_rotation_limit_max=-29,
+        z_rotation_limit_min=-30,
+        z_rotation_limit_max=-20,
+        new_head_metacarpal_ratio=0.30,
+        angle_offset=25.0,
     ),
     'palm.04.L': BoneDefinition(
         head='left_hand_wrist',
@@ -429,8 +441,10 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='hand.L',
         x_rotation_limit_min=-180,
         x_rotation_limit_max=180,
-        z_rotation_limit_min=-31,
-        z_rotation_limit_max=-29,
+        z_rotation_limit_min=-30,
+        z_rotation_limit_max=-20,
+        new_head_metacarpal_ratio=0.30,
+        angle_offset=25.0,
     ),
     'f_pinky.01.R': BoneDefinition(
         head='right_hand_pinky_mcp',
@@ -459,8 +473,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='f_pinky.01.R',
         x_rotation_limit_min=0,
         x_rotation_limit_max=90,
-        z_rotation_limit_min=-1,
-        z_rotation_limit_max=1,
+        z_rotation_limit_min=-2,
+        z_rotation_limit_max=2,
     ),
     'f_pinky.02.L': BoneDefinition(
         head='left_hand_pinky_pip',
@@ -469,8 +483,8 @@ _BONE_DEFINITIONS: Dict[str, BoneDefinition] = {
         parent_bone='f_pinky.01.L',
         x_rotation_limit_min=-90,
         x_rotation_limit_max=0,
-        z_rotation_limit_min=-1,
-        z_rotation_limit_max=1,
+        z_rotation_limit_min=-2,
+        z_rotation_limit_max=2,
     ),
     'f_pinky.03.R': BoneDefinition(
         head='right_hand_pinky_dip',


### PR DESCRIPTION
@jonmatthis I updated the limit range of motion function. The changes are the following:

- Added a damped track marker selector for the initial hand bone direction. I left as default the hand_middle_finger_mcp as all the finger bones are oriented in that direction.
- Added the hand_index_finger_mcp as an option for the locked track marker. That provides better results than the simple hand_index and the hand_thumb_cmc markers. I think in the future the armature hand bone constraints and markers would need a revision to probably use this combination of markers as well.
- Added a logic to recalculate the head position of the metacarpals so they are placed at a more natural position than the wrist. I added a metacarpal ratio and an angle offset to the bone definitions to help in those calculations.
- Modified some z axis limit angles to not make the corrections so strict.